### PR TITLE
fix: make terminal cursor visible

### DIFF
--- a/src/lazyagent/widgets/scrollable_terminal.py
+++ b/src/lazyagent/widgets/scrollable_terminal.py
@@ -120,6 +120,10 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         self._screen = ScrollbackScreen(self.ncol, self.nrow)
         self.stream = pyte.Stream(self._screen)
 
+        # Cached resolved default colors (invalidated on theme change)
+        self._cached_default_fg: str | None = None
+        self._cached_default_bg: str | None = None
+
         # Key translation table (same as textual-terminal)
         self.ctrl_keys = {
             "up": "\x1bOA",
@@ -332,7 +336,7 @@ class ScrollableTerminal(ScrollView, can_focus=True):
             not self._screen.cursor.hidden
             and self._screen.cursor.y == screen_y
         )
-        return self._row_to_strip(row, width, show_cursor=show_cursor, screen_y=screen_y)
+        return self._row_to_strip(row, width, show_cursor=show_cursor)
 
     def _row_to_strip(
         self,
@@ -340,7 +344,6 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         width: int,
         *,
         show_cursor: bool = False,
-        screen_y: int = -1,
     ) -> Strip:
         """Convert a pyte row (dict of column→Char) to a textual Strip."""
         text = Text()
@@ -375,6 +378,23 @@ class ScrollableTerminal(ScrollView, can_focus=True):
     # Style helpers (ported from textual-terminal Terminal)
     # ------------------------------------------------------------------
 
+    def notify_style_update(self) -> None:
+        self._cached_default_fg = None
+        self._cached_default_bg = None
+        super().notify_style_update()
+
+    def _resolved_default_colors(self) -> tuple[str, str]:
+        """Return resolved (fg, bg) for default/inherited colors, cached."""
+        if self._cached_default_fg is None:
+            wstyle = self.rich_style
+            self._cached_default_fg = (
+                wstyle.color.name if wstyle.color and wstyle.color.name else "white"
+            )
+            self._cached_default_bg = (
+                wstyle.bgcolor.name if wstyle.bgcolor and wstyle.bgcolor.name else "black"
+            )
+        return self._cached_default_fg, self._cached_default_bg
+
     @staticmethod
     def _char_style_cmp(given: Char, other: Char) -> bool:
         """Return True if two pyte Chars have the same style."""
@@ -406,19 +426,18 @@ class ScrollableTerminal(ScrollView, can_focus=True):
 
         Swaps the cell's fg/bg so the cursor appears as a solid block.
         When the cell uses default (inherited) colors, resolves actual
-        colors from the widget's own style so the swap produces visible
+        colors from the cached widget theme so the swap produces visible
         contrast — bare ``reverse`` on two default colors is a no-op.
         """
         cell_fg = self._detect_color(char.fg)
         cell_bg = self._detect_color(char.bg)
 
-        # Resolve "default" to the widget's actual theme colors
-        if cell_fg == "default":
-            wstyle = self.rich_style
-            cell_fg = wstyle.color.name if wstyle.color else "white"
-        if cell_bg == "default":
-            wstyle = self.rich_style
-            cell_bg = wstyle.bgcolor.name if wstyle.bgcolor else "black"
+        if cell_fg == "default" or cell_bg == "default":
+            default_fg, default_bg = self._resolved_default_colors()
+            if cell_fg == "default":
+                cell_fg = default_fg
+            if cell_bg == "default":
+                cell_bg = default_bg
 
         # Cursor = swapped fg/bg
         return Style(color=cell_bg, bgcolor=cell_fg)

--- a/src/lazyagent/widgets/scrollable_terminal.py
+++ b/src/lazyagent/widgets/scrollable_terminal.py
@@ -328,7 +328,10 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         if screen_y < 0 or screen_y >= self._screen.lines:
             return Strip.blank(width, self.rich_style)
         row = self._screen.buffer[screen_y]
-        show_cursor = self._screen.cursor.y == screen_y
+        show_cursor = (
+            not self._screen.cursor.hidden
+            and self._screen.cursor.y == screen_y
+        )
         return self._row_to_strip(row, width, show_cursor=show_cursor, screen_y=screen_y)
 
     def _row_to_strip(
@@ -358,12 +361,12 @@ class ScrollableTerminal(ScrollView, can_focus=True):
                     text.stylize(last_style, style_change_pos, x + 1)
                     style_change_pos = x
 
-            if (
-                show_cursor
-                and self._screen.cursor.x == x
-                and self._screen.cursor.y == screen_y
-            ):
-                text.stylize("reverse", x, x + 1)
+        # Apply cursor style AFTER all character styles so it is never
+        # overwritten by a later stylize() call that covers the same range.
+        if show_cursor and 0 <= self._screen.cursor.x < ncols:
+            cx = self._screen.cursor.x
+            cursor_char: Char = row.get(cx, self._screen.default_char)
+            text.stylize(self._cursor_style(cursor_char), cx, cx + 1)
 
         segments = list(text.render(self.app.console))
         return Strip(segments)
@@ -397,6 +400,28 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         if re.match("[0-9a-f]{6}", color, re.IGNORECASE):
             return f"#{color}"
         return color
+
+    def _cursor_style(self, char: Char) -> Style:
+        """Build a block-cursor style for the given cell.
+
+        Swaps the cell's fg/bg so the cursor appears as a solid block.
+        When the cell uses default (inherited) colors, resolves actual
+        colors from the widget's own style so the swap produces visible
+        contrast — bare ``reverse`` on two default colors is a no-op.
+        """
+        cell_fg = self._detect_color(char.fg)
+        cell_bg = self._detect_color(char.bg)
+
+        # Resolve "default" to the widget's actual theme colors
+        if cell_fg == "default":
+            wstyle = self.rich_style
+            cell_fg = wstyle.color.name if wstyle.color else "white"
+        if cell_bg == "default":
+            wstyle = self.rich_style
+            cell_bg = wstyle.bgcolor.name if wstyle.bgcolor else "black"
+
+        # Cursor = swapped fg/bg
+        return Style(color=cell_bg, bgcolor=cell_fg)
 
     def _char_rich_style(self, char: Char) -> Style:
         """Convert a pyte Char's attributes to a ``rich.Style``."""

--- a/tests/test_scrollable_terminal.py
+++ b/tests/test_scrollable_terminal.py
@@ -1,10 +1,11 @@
 """Tests for ScrollbackScreen and ScrollableTerminal."""
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch, PropertyMock
 
 import pyte
 from pyte.screens import Char
+from rich.style import Style
 
 from lazyagent.widgets.scrollable_terminal import ScrollableTerminal, ScrollbackScreen
 
@@ -99,6 +100,8 @@ def _make_scrollable_terminal() -> ScrollableTerminal:
     terminal._screen = ScrollbackScreen(80, 5)
     terminal.stream = pyte.Stream(terminal._screen)
     terminal.ctrl_keys = {}
+    terminal._cached_default_fg = None
+    terminal._cached_default_bg = None
     return terminal
 
 
@@ -181,3 +184,123 @@ class TestStyleHelpers:
     def test_detect_color_passthrough(self):
         assert ScrollableTerminal._detect_color("red") == "red"
         assert ScrollableTerminal._detect_color("default") == "default"
+
+
+class TestCursorStyle:
+    """Tests for _cursor_style and the cached default color resolution."""
+
+    def _make_terminal_with_style(self, fg="white", bg="black"):
+        """Create a terminal with a mocked rich_style returning given colors."""
+        t = _make_scrollable_terminal()
+        style = Style(color=fg, bgcolor=bg)
+        patcher = patch.object(
+            type(t), "rich_style", new_callable=lambda: property(lambda self: style)
+        )
+        patcher.start()
+        # Ensure cache is clean so first call resolves
+        t._cached_default_fg = None
+        t._cached_default_bg = None
+        return t, patcher
+
+    def test_cursor_swaps_fg_bg_for_default_colors(self):
+        """Cursor on a default-color cell swaps resolved theme colors."""
+        t, patcher = self._make_terminal_with_style("white", "black")
+        try:
+            char = Char("x", "default", "default", False, False, False, False, False, False)
+            style = t._cursor_style(char)
+            # fg/bg should be swapped: cursor fg=theme bg, cursor bg=theme fg
+            assert style.color.name == "black"
+            assert style.bgcolor.name == "white"
+        finally:
+            patcher.stop()
+
+    def test_cursor_swaps_explicit_colors(self):
+        """Cursor on a cell with explicit fg/bg swaps those colors directly."""
+        t = _make_scrollable_terminal()
+        char = Char("x", "red", "blue", False, False, False, False, False, False)
+        style = t._cursor_style(char)
+        assert style.color.name == "blue"
+        assert style.bgcolor.name == "red"
+
+    def test_cursor_mixed_default_and_explicit(self):
+        """When only fg is default, it resolves from theme; bg stays explicit."""
+        t, patcher = self._make_terminal_with_style("green", "magenta")
+        try:
+            char = Char("x", "default", "red", False, False, False, False, False, False)
+            style = t._cursor_style(char)
+            # fg was default → resolved to "green", bg was "red"
+            # cursor swaps: color=bg("red"), bgcolor=fg("green")
+            assert style.color.name == "red"
+            assert style.bgcolor.name == "green"
+        finally:
+            patcher.stop()
+
+    def test_cursor_respects_hidden_flag(self):
+        """When cursor.hidden is set, show_cursor should be False."""
+        t = _make_scrollable_terminal()
+        t._screen.cursor.hidden = True
+        t._screen.cursor.y = 0
+        show_cursor = not t._screen.cursor.hidden and t._screen.cursor.y == 0
+        assert show_cursor is False
+
+
+class TestResolvedDefaultColors:
+    """Tests for _resolved_default_colors caching and invalidation."""
+
+    def test_caches_resolved_colors(self):
+        """rich_style is resolved once and then cached."""
+        t = _make_scrollable_terminal()
+        style = Style(color="cyan", bgcolor="yellow")
+        call_count = 0
+
+        def counting_style(self):
+            nonlocal call_count
+            call_count += 1
+            return style
+
+        with patch.object(type(t), "rich_style", new_callable=lambda: property(counting_style)):
+            fg1, bg1 = t._resolved_default_colors()
+            fg2, bg2 = t._resolved_default_colors()
+
+        assert (fg1, bg1) == ("cyan", "yellow")
+        assert (fg2, bg2) == ("cyan", "yellow")
+        assert call_count == 1  # resolved only once
+
+    def test_notify_style_update_invalidates_cache(self):
+        """notify_style_update clears cached colors so next call re-resolves."""
+        t = _make_scrollable_terminal()
+        style_v1 = Style(color="white", bgcolor="black")
+        style_v2 = Style(color="green", bgcolor="blue")
+        current_style = [style_v1]
+
+        with patch.object(
+            type(t), "rich_style",
+            new_callable=lambda: property(lambda self: current_style[0]),
+        ), patch.object(
+            # super().notify_style_update() touches Widget internals not
+            # present on our __new__-constructed instance; bypass it.
+            type(t).__mro__[1], "notify_style_update", lambda self: None,
+        ):
+            fg1, bg1 = t._resolved_default_colors()
+            assert (fg1, bg1) == ("white", "black")
+
+            # Simulate theme change
+            current_style[0] = style_v2
+            t.notify_style_update()
+
+            fg2, bg2 = t._resolved_default_colors()
+            assert (fg2, bg2) == ("green", "blue")
+
+    def test_fallback_when_style_has_no_color(self):
+        """Falls back to white/black when rich_style has no color set."""
+        t = _make_scrollable_terminal()
+        empty_style = Style()  # no color, no bgcolor
+
+        with patch.object(
+            type(t), "rich_style",
+            new_callable=lambda: property(lambda self: empty_style),
+        ):
+            fg, bg = t._resolved_default_colors()
+
+        assert fg == "white"
+        assert bg == "black"

--- a/tests/test_scrollable_terminal.py
+++ b/tests/test_scrollable_terminal.py
@@ -1,7 +1,7 @@
 """Tests for ScrollbackScreen and ScrollableTerminal."""
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import pyte
 from pyte.screens import Char

--- a/uv.lock
+++ b/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "lazyagent"
-version = "0.2.2"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyte" },


### PR DESCRIPTION
## Summary
- Move cursor `stylize()` call **after** the character-style loop so it is never overwritten by a later full-row style application
- Replace bare `"reverse"` with explicit fg/bg color swap that resolves default theme colors, fixing invisible cursors when both fg and bg are unset
- Skip cursor rendering when `cursor.hidden` is set by the PTY program

## Test plan
- [x] Verified cursor is visible in the terminal pane (bash prompt)
- [x] Verified cursor remains visible in the agent pane
- [x] Verify cursor renders correctly with colored prompts (e.g. starship, oh-my-zsh)
- [x] Verify cursor hides when a program sets DECTCEM (e.g. `tput civis`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)