### PR TITLE
feat: pass initial instruction to spawned agents

### DIFF
--- a/src/lazyagent/agent_providers.py
+++ b/src/lazyagent/agent_providers.py
@@ -53,6 +53,7 @@ class AgentProvider:
     resume_pick_args: tuple[str, ...] = ()
     resume_last_args: tuple[str, ...] = ()
     resume_is_subcommand: bool = False
+    instruction_flag: str | None = None
 
     def build_command(
         self,
@@ -60,6 +61,7 @@ class AgentProvider:
         skip_permissions: bool = False,
         runtime_context: ProviderRuntimeContext | None = None,
         resume_mode: ResumeMode = ResumeMode.NEW,
+        instruction: str | None = None,
     ) -> str:
         """Build the full shell command used to launch this provider."""
         context = runtime_context or self.build_runtime_context(worktree_path)
@@ -75,6 +77,12 @@ class AgentProvider:
 
         if skip_permissions:
             parts.append(self.dangerous_flag)
+
+        if instruction:
+            if self.instruction_flag:
+                parts.extend([self.instruction_flag, instruction])
+            else:
+                parts.append(instruction)
 
         if "settings_path" in context.metadata:
             parts.extend(["--settings", context.metadata["settings_path"]])
@@ -183,6 +191,7 @@ PROVIDERS = {
         supports_completion_events=True,
         resume_pick_args=("--resume",),
         resume_last_args=("--resume",),
+        instruction_flag="-i",
     ),
 }
 

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -281,6 +281,7 @@ class LazyAgent(App):
                     skip_permissions=result.skip_permissions,
                     agent_provider=self._config.agent.provider,
                     resume_mode=result.resume_mode,
+                    instruction=result.instruction,
                 )
 
         self.push_screen(SpawnModal(worktree.display_label, agent_provider=self._config.agent.provider), on_spawn_dismiss)

--- a/src/lazyagent/widgets/center_panel.py
+++ b/src/lazyagent/widgets/center_panel.py
@@ -242,7 +242,7 @@ class WorktreePanel(Container):
         skip_permissions: bool = False,
         agent_provider: str = DEFAULT_AGENT_PROVIDER,
         resume_mode: ResumeMode = ResumeMode.NEW,
-        instruction: str = "",
+        instruction: str | None = None,
     ) -> None:
         """Spawn the configured coding agent process in the Agent pane."""
         pane = self.query_one("#agent-tab", TabPane)
@@ -267,7 +267,7 @@ class WorktreePanel(Container):
             skip_permissions=skip_permissions,
             runtime_context=runtime_context,
             resume_mode=resume_mode,
-            instruction=instruction or None,
+            instruction=instruction,
         )
 
         terminal = MonitoredTerminal(

--- a/src/lazyagent/widgets/center_panel.py
+++ b/src/lazyagent/widgets/center_panel.py
@@ -242,6 +242,7 @@ class WorktreePanel(Container):
         skip_permissions: bool = False,
         agent_provider: str = DEFAULT_AGENT_PROVIDER,
         resume_mode: ResumeMode = ResumeMode.NEW,
+        instruction: str = "",
     ) -> None:
         """Spawn the configured coding agent process in the Agent pane."""
         pane = self.query_one("#agent-tab", TabPane)
@@ -266,6 +267,7 @@ class WorktreePanel(Container):
             skip_permissions=skip_permissions,
             runtime_context=runtime_context,
             resume_mode=resume_mode,
+            instruction=instruction or None,
         )
 
         terminal = MonitoredTerminal(

--- a/src/lazyagent/widgets/prompt_modal.py
+++ b/src/lazyagent/widgets/prompt_modal.py
@@ -15,7 +15,7 @@ from lazyagent.agent_providers import DEFAULT_AGENT_PROVIDER, ResumeMode, get_ag
 class SpawnResult:
     skip_permissions: bool
     resume_mode: ResumeMode = ResumeMode.NEW
-    instruction: str = ""
+    instruction: str | None = None
 
 
 _LABELS_DISTINCT: dict[ResumeMode, str] = {

--- a/src/lazyagent/widgets/prompt_modal.py
+++ b/src/lazyagent/widgets/prompt_modal.py
@@ -15,6 +15,7 @@ from lazyagent.agent_providers import DEFAULT_AGENT_PROVIDER, ResumeMode, get_ag
 class SpawnResult:
     skip_permissions: bool
     resume_mode: ResumeMode = ResumeMode.NEW
+    instruction: str = ""
 
 
 _LABELS_DISTINCT: dict[ResumeMode, str] = {

--- a/tests/test_agent_providers.py
+++ b/tests/test_agent_providers.py
@@ -190,3 +190,77 @@ class TestBuildCommandResume:
             get_agent_provider("gemini").build_command("/tmp/wt", resume_mode=ResumeMode.NEW)
         )[2]
         assert "--resume" not in script
+
+
+class TestBuildCommandInstruction:
+    def test_claude_instruction_as_positional_arg(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command("/tmp/wt", instruction="do stuff")
+        )[2]
+        exec_part = script.split("exec ")[1]
+        assert "'do stuff'" in exec_part or "do stuff" in exec_part
+
+    def test_codex_instruction_as_positional_arg(self):
+        script = shlex.split(
+            get_agent_provider("codex").build_command("/tmp/wt", instruction="fix bug")
+        )[2]
+        exec_part = script.split("exec ")[1]
+        assert "'fix bug'" in exec_part or "fix bug" in exec_part
+
+    def test_gemini_instruction_via_flag(self):
+        script = shlex.split(
+            get_agent_provider("gemini").build_command("/tmp/wt", instruction="hello")
+        )[2]
+        exec_part = script.split("exec ")[1]
+        assert "-i" in exec_part
+        assert "hello" in exec_part
+
+    def test_no_instruction_when_none(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command("/tmp/wt", instruction=None)
+        )[2]
+        exec_part = script.split("exec ")[1]
+        # Should only have claude + settings, no extra positional
+        parts = shlex.split(exec_part)
+        assert parts[0] == "claude"
+        # No stray positional args (only --settings and its value)
+        non_flag_parts = [p for p in parts[1:] if not p.startswith("--") and "settings" not in parts[parts.index(p) - 1]]
+        assert len(non_flag_parts) == 0
+
+    def test_no_instruction_when_empty_string(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command("/tmp/wt", instruction="")
+        )[2]
+        exec_part = script.split("exec ")[1]
+        parts = shlex.split(exec_part)
+        assert parts[0] == "claude"
+        non_flag_parts = [p for p in parts[1:] if not p.startswith("--") and "settings" not in parts[parts.index(p) - 1]]
+        assert len(non_flag_parts) == 0
+
+    def test_instruction_with_special_chars_is_escaped(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command(
+                "/tmp/wt", instruction="hello 'world' && rm -rf /"
+            )
+        )[2]
+        # The instruction must survive shell escaping — it should appear quoted
+        assert "hello" in script
+        assert "rm -rf" in script
+
+    def test_instruction_combined_with_resume(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command(
+                "/tmp/wt", resume_mode=ResumeMode.RESUME_LAST, instruction="continue task"
+            )
+        )[2]
+        assert "--continue" in script
+        assert "continue task" in script
+
+    def test_instruction_combined_with_skip_permissions(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command(
+                "/tmp/wt", skip_permissions=True, instruction="deploy now"
+            )
+        )[2]
+        assert "--dangerously-skip-permissions" in script
+        assert "deploy now" in script

--- a/tests/test_agent_providers.py
+++ b/tests/test_agent_providers.py
@@ -220,12 +220,11 @@ class TestBuildCommandInstruction:
             get_agent_provider("claude").build_command("/tmp/wt", instruction=None)
         )[2]
         exec_part = script.split("exec ")[1]
-        # Should only have claude + settings, no extra positional
+        # Should only have claude + --settings <path>
         parts = shlex.split(exec_part)
         assert parts[0] == "claude"
-        # No stray positional args (only --settings and its value)
-        non_flag_parts = [p for p in parts[1:] if not p.startswith("--") and "settings" not in parts[parts.index(p) - 1]]
-        assert len(non_flag_parts) == 0
+        assert parts[1] == "--settings"
+        assert len(parts) == 3
 
     def test_no_instruction_when_empty_string(self):
         script = shlex.split(
@@ -234,8 +233,8 @@ class TestBuildCommandInstruction:
         exec_part = script.split("exec ")[1]
         parts = shlex.split(exec_part)
         assert parts[0] == "claude"
-        non_flag_parts = [p for p in parts[1:] if not p.startswith("--") and "settings" not in parts[parts.index(p) - 1]]
-        assert len(non_flag_parts) == 0
+        assert parts[1] == "--settings"
+        assert len(parts) == 3
 
     def test_instruction_with_special_chars_is_escaped(self):
         script = shlex.split(

--- a/tests/test_center_panel.py
+++ b/tests/test_center_panel.py
@@ -11,12 +11,14 @@ def _build_spawn_command(
     skip_permissions: bool = False,
     agent_provider: str = "claude",
     resume_mode: ResumeMode = ResumeMode.NEW,
+    instruction: str = "",
 ) -> str:
     """Reproduce the command-building logic from WorktreePanel.spawn_agent."""
     return get_agent_provider(agent_provider).build_command(
         worktree_path,
         skip_permissions=skip_permissions,
         resume_mode=resume_mode,
+        instruction=instruction or None,
     )
 
 
@@ -99,6 +101,35 @@ class TestCommandBuilding:
         assert "--approval-mode=yolo" in script
         assert "--append-system-prompt" not in script
         assert "--yolo" not in script
+
+
+class TestCommandBuildingWithInstruction:
+    def test_instruction_appears_in_claude_command(self):
+        cmd = _build_spawn_command("/tmp/wt", instruction="fix the bug")
+        script = shlex.split(cmd)[2]
+        assert "fix the bug" in script
+
+    def test_instruction_appears_in_gemini_command_with_flag(self):
+        cmd = _build_spawn_command("/tmp/wt", agent_provider="gemini", instruction="hello")
+        script = shlex.split(cmd)[2]
+        exec_part = script.split("exec ")[1]
+        assert "-i" in exec_part
+        assert "hello" in exec_part
+
+    def test_empty_instruction_not_in_command(self):
+        cmd = _build_spawn_command("/tmp/wt", instruction="")
+        script = shlex.split(cmd)[2]
+        exec_part = script.split("exec ")[1]
+        # Only claude + settings flag args
+        parts = shlex.split(exec_part)
+        assert parts[0] == "claude"
+        assert "-i" not in parts
+
+    def test_instruction_with_skip_permissions(self):
+        cmd = _build_spawn_command("/tmp/wt", skip_permissions=True, instruction="deploy")
+        script = shlex.split(cmd)[2]
+        assert "--dangerously-skip-permissions" in script
+        assert "deploy" in script
 
 
 class TestEnvExports:

--- a/tests/test_center_panel.py
+++ b/tests/test_center_panel.py
@@ -11,14 +11,12 @@ def _build_spawn_command(
     skip_permissions: bool = False,
     agent_provider: str = "claude",
     resume_mode: ResumeMode = ResumeMode.NEW,
-    instruction: str = "",
 ) -> str:
     """Reproduce the command-building logic from WorktreePanel.spawn_agent."""
     return get_agent_provider(agent_provider).build_command(
         worktree_path,
         skip_permissions=skip_permissions,
         resume_mode=resume_mode,
-        instruction=instruction or None,
     )
 
 
@@ -101,35 +99,6 @@ class TestCommandBuilding:
         assert "--approval-mode=yolo" in script
         assert "--append-system-prompt" not in script
         assert "--yolo" not in script
-
-
-class TestCommandBuildingWithInstruction:
-    def test_instruction_appears_in_claude_command(self):
-        cmd = _build_spawn_command("/tmp/wt", instruction="fix the bug")
-        script = shlex.split(cmd)[2]
-        assert "fix the bug" in script
-
-    def test_instruction_appears_in_gemini_command_with_flag(self):
-        cmd = _build_spawn_command("/tmp/wt", agent_provider="gemini", instruction="hello")
-        script = shlex.split(cmd)[2]
-        exec_part = script.split("exec ")[1]
-        assert "-i" in exec_part
-        assert "hello" in exec_part
-
-    def test_empty_instruction_not_in_command(self):
-        cmd = _build_spawn_command("/tmp/wt", instruction="")
-        script = shlex.split(cmd)[2]
-        exec_part = script.split("exec ")[1]
-        # Only claude + settings flag args
-        parts = shlex.split(exec_part)
-        assert parts[0] == "claude"
-        assert "-i" not in parts
-
-    def test_instruction_with_skip_permissions(self):
-        cmd = _build_spawn_command("/tmp/wt", skip_permissions=True, instruction="deploy")
-        script = shlex.split(cmd)[2]
-        assert "--dangerously-skip-permissions" in script
-        assert "deploy" in script
 
 
 class TestEnvExports:


### PR DESCRIPTION
## Summary
- Add `instruction_flag` field to `AgentProvider` and `instruction` param to `build_command()` so the orchestrator/MCP can tell spawned agents what to do via CLI arg (no PTY writes needed)
- Claude/Codex append instruction as a positional arg; Gemini uses `-i` flag
- Plumbing wired through `spawn_agent()` and the app callback for programmatic use — the spawn modal UI is unchanged

## Test plan
- [x] All 266 existing tests pass
- [x] 12 new tests covering: positional arg (Claude/Codex), flag arg (Gemini), None/empty no-op, shell escaping, combined with resume mode, combined with skip-permissions
- [ ] Manual: programmatically call `spawn_agent(instruction="...")` and verify the CLI command includes the instruction

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)