### PR TITLE
feat: orchestrator system prompt (#27, #28, #29)

### DIFF
--- a/src/lazyagent/agent_providers.py
+++ b/src/lazyagent/agent_providers.py
@@ -54,6 +54,7 @@ class AgentProvider:
     resume_last_args: tuple[str, ...] = ()
     resume_is_subcommand: bool = False
     instruction_flag: str | None = None
+    system_prompt_flag: str | None = None
 
     def build_command(
         self,
@@ -62,6 +63,7 @@ class AgentProvider:
         runtime_context: ProviderRuntimeContext | None = None,
         resume_mode: ResumeMode = ResumeMode.NEW,
         instruction: str | None = None,
+        system_prompt: str | None = None,
     ) -> str:
         """Build the full shell command used to launch this provider."""
         context = runtime_context or self.build_runtime_context(worktree_path)
@@ -77,6 +79,15 @@ class AgentProvider:
 
         if skip_permissions:
             parts.append(self.dangerous_flag)
+
+        if system_prompt:
+            if self.system_prompt_flag:
+                parts.extend([self.system_prompt_flag, system_prompt])
+            elif instruction:
+                # Providers without a dedicated flag: prepend to instruction
+                instruction = system_prompt + "\n\n" + instruction
+            else:
+                instruction = system_prompt
 
         if instruction:
             if self.instruction_flag:
@@ -174,6 +185,7 @@ PROVIDERS = {
         supports_completion_events=True,
         resume_pick_args=("--resume",),
         resume_last_args=("--continue",),
+        system_prompt_flag="--append-system-prompt",
     ),
     "codex": AgentProvider(
         name="codex",

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -74,7 +74,6 @@ class LazyAgent(App):
         self._git_statuses: dict[str, GitStatus] = {}
         self._selected_worktree: WorktreeInfo | None = None
         self._orchestrator_selected: bool = False
-        self._orchestrator_state: AgentState = AgentState()
         self._config: Config = Config()
         self._repo_root: str = ""
         self._gh_available: bool | None = None
@@ -149,10 +148,18 @@ class LazyAgent(App):
             return wt_list.highlighted_child.worktree
         return None
 
-    def _get_agent_state(self, worktree_path: str) -> AgentState:
-        if worktree_path not in self._agent_states:
-            self._agent_states[worktree_path] = AgentState()
-        return self._agent_states[worktree_path]
+    def _get_agent_state(self, key: str) -> AgentState:
+        """Get or create AgentState for a worktree path or ORCHESTRATOR_KEY."""
+        if key not in self._agent_states:
+            self._agent_states[key] = AgentState()
+        return self._agent_states[key]
+
+    def _get_any_panel(self, key: str):
+        """Get the panel for a worktree path or ORCHESTRATOR_KEY."""
+        center = self.query_one(CenterPanel)
+        if key == ORCHESTRATOR_KEY:
+            return center.get_orchestrator_panel()
+        return center.get_panel(key)
 
     def _refresh_git_statuses(self) -> None:
         """Fetch git statuses for all worktrees and push to UI."""
@@ -221,7 +228,7 @@ class LazyAgent(App):
         if event.item is not None and isinstance(event.item, OrchestratorListItem):
             self._orchestrator_selected = True
             self._selected_worktree = None
-            center.switch_to_orchestrator()
+            center.switch_to_orchestrator(self._repo_root)
         elif event.item is not None and isinstance(event.item, WorktreeListItem):
             self._orchestrator_selected = False
             self._selected_worktree = event.item.worktree
@@ -236,50 +243,17 @@ class LazyAgent(App):
     # --- Agent message handlers ---
 
     def on_agent_status_changed(self, event: AgentStatusChanged) -> None:
-        if event.worktree_path == ORCHESTRATOR_KEY:
-            self._orchestrator_state.status = event.status
-            self._orchestrator_state.confidence = event.confidence
-            self._orchestrator_state.detail = event.detail
-            if event.status == AgentStatus.RUNNING:
-                center = self.query_one(CenterPanel)
-                panel = center.get_orchestrator_panel()
-                if panel and panel.agent_terminal:
-                    self._orchestrator_state.last_output_time = panel.agent_terminal.last_output_time
-            self.query_one(WorktreeList).update_orchestrator_state(self._orchestrator_state)
-            return
-
         state = self._get_agent_state(event.worktree_path)
         state.status = event.status
         state.confidence = event.confidence
         state.detail = event.detail
         if event.status == AgentStatus.RUNNING:
-            # Update last_output_time from the terminal
-            center = self.query_one(CenterPanel)
-            panel = center.get_panel(event.worktree_path)
+            panel = self._get_any_panel(event.worktree_path)
             if panel and panel.agent_terminal:
                 state.last_output_time = panel.agent_terminal.last_output_time
         self.query_one(WorktreeList).update_agent_state(event.worktree_path, state)
 
     async def on_agent_exited(self, event: AgentExited) -> None:
-        if event.worktree_path == ORCHESTRATOR_KEY:
-            self._orchestrator_state.status = AgentStatus.NO_AGENT
-            self._orchestrator_state.confidence = LifecycleConfidence.LOW
-            self._orchestrator_state.detail = ""
-            self._orchestrator_state.last_output_time = None
-            self.query_one(WorktreeList).update_orchestrator_state(self._orchestrator_state)
-
-            center = self.query_one(CenterPanel)
-            panel = center.get_orchestrator_panel()
-            if panel is not None:
-                await panel.cleanup_agent()
-
-            self.notify(
-                "Orchestrator exited — press s to spawn again",
-                severity="warning",
-                timeout=5,
-            )
-            return
-
         state = self._get_agent_state(event.worktree_path)
         state.status = AgentStatus.NO_AGENT
         state.confidence = LifecycleConfidence.LOW
@@ -287,13 +261,13 @@ class LazyAgent(App):
         state.last_output_time = None
         self.query_one(WorktreeList).update_agent_state(event.worktree_path, state)
 
-        center = self.query_one(CenterPanel)
-        panel = center.get_panel(event.worktree_path)
+        panel = self._get_any_panel(event.worktree_path)
         if panel is not None:
             await panel.cleanup_agent()
 
+        label = "Orchestrator" if event.worktree_path == ORCHESTRATOR_KEY else "Agent"
         self.notify(
-            "Agent exited — press s to spawn again",
+            f"{label} exited — press s to spawn again",
             severity="warning",
             timeout=5,
         )
@@ -302,17 +276,9 @@ class LazyAgent(App):
 
     def _check_hangs(self) -> None:
         """Periodic timer callback: check all active agents for hangs."""
-        center = self.query_one(CenterPanel)
-
-        # Check orchestrator
-        if self._orchestrator_state.status == AgentStatus.RUNNING:
-            orch_panel = center.get_orchestrator_panel()
-            if orch_panel and orch_panel.agent_terminal:
-                orch_panel.agent_terminal.check_hang()
-
-        for worktree_path, state in self._agent_states.items():
+        for key, state in self._agent_states.items():
             if state.status == AgentStatus.RUNNING:
-                panel = center.get_panel(worktree_path)
+                panel = self._get_any_panel(key)
                 if panel and panel.agent_terminal:
                     panel.agent_terminal.check_hang()
 
@@ -351,18 +317,16 @@ class LazyAgent(App):
 
     def _spawn_orchestrator_agent(self) -> None:
         """Spawn agent in the orchestrator panel."""
-        center = self.query_one(CenterPanel)
-        orch_panel = center.get_orchestrator_panel()
-        if orch_panel and orch_panel.has_agent:
+        panel = self._get_any_panel(ORCHESTRATOR_KEY)
+        if panel and panel.has_agent:
             self.notify("Orchestrator agent already running", severity="warning")
             return
 
         async def on_spawn_dismiss(result: SpawnResult | None) -> None:
             if result is not None:
                 center = self.query_one(CenterPanel)
-                panel = center.switch_to_orchestrator()
+                panel = center.switch_to_orchestrator(self._repo_root)
                 await panel.spawn_agent(
-                    worktree_path=self._repo_root,
                     skip_permissions=result.skip_permissions,
                     agent_provider=self._config.agent.provider,
                     resume_mode=result.resume_mode,
@@ -398,15 +362,15 @@ class LazyAgent(App):
 
     async def _stop_orchestrator_agent(self) -> None:
         """Stop the orchestrator agent."""
-        center = self.query_one(CenterPanel)
-        panel = center.get_orchestrator_panel()
+        panel = self._get_any_panel(ORCHESTRATOR_KEY)
         if panel is None or not panel.has_agent:
             self.notify("No running orchestrator agent", severity="warning")
             return
 
-        self._orchestrator_state.status = AgentStatus.NO_AGENT
-        self._orchestrator_state.last_output_time = None
-        self.query_one(WorktreeList).update_orchestrator_state(self._orchestrator_state)
+        state = self._get_agent_state(ORCHESTRATOR_KEY)
+        state.status = AgentStatus.NO_AGENT
+        state.last_output_time = None
+        self.query_one(WorktreeList).update_agent_state(ORCHESTRATOR_KEY, state)
         await panel.cleanup_agent()
         self.notify("Orchestrator agent stopped")
 

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -20,7 +20,8 @@ from lazyagent.widgets.create_worktree_modal import CreateWorktreeModal, CreateW
 from lazyagent.widgets.remove_worktree_modal import RemoveWorktreeModal, RemoveWorktreeResult
 from lazyagent.widgets.pr_status_bar import PrStatusBar
 from lazyagent.widgets.prompt_modal import SpawnModal, SpawnResult
-from lazyagent.widgets.worktree_list import WorktreeList, WorktreeListItem
+from lazyagent.widgets.orchestrator_panel import ORCHESTRATOR_KEY
+from lazyagent.widgets.worktree_list import OrchestratorListItem, WorktreeList, WorktreeListItem
 from lazyagent.worktree_manager import WorktreeManager, WorktreeManagerError, find_repo_root
 
 
@@ -72,6 +73,8 @@ class LazyAgent(App):
         self._agent_states: dict[str, AgentState] = {}
         self._git_statuses: dict[str, GitStatus] = {}
         self._selected_worktree: WorktreeInfo | None = None
+        self._orchestrator_selected: bool = False
+        self._orchestrator_state: AgentState = AgentState()
         self._config: Config = Config()
         self._repo_root: str = ""
         self._gh_available: bool | None = None
@@ -215,18 +218,36 @@ class LazyAgent(App):
 
     def on_list_view_highlighted(self, event: WorktreeList.Highlighted) -> None:
         center = self.query_one(CenterPanel)
-        if event.item is not None and isinstance(event.item, WorktreeListItem):
+        if event.item is not None and isinstance(event.item, OrchestratorListItem):
+            self._orchestrator_selected = True
+            self._selected_worktree = None
+            center.switch_to_orchestrator()
+        elif event.item is not None and isinstance(event.item, WorktreeListItem):
+            self._orchestrator_selected = False
             self._selected_worktree = event.item.worktree
             center.switch_to(event.item.worktree.path)
             self._push_git_status_to_selected_panel()
             self._refresh_selected_diff()
             self._refresh_pr_status()
         else:
+            self._orchestrator_selected = False
             self._selected_worktree = None
 
     # --- Agent message handlers ---
 
     def on_agent_status_changed(self, event: AgentStatusChanged) -> None:
+        if event.worktree_path == ORCHESTRATOR_KEY:
+            self._orchestrator_state.status = event.status
+            self._orchestrator_state.confidence = event.confidence
+            self._orchestrator_state.detail = event.detail
+            if event.status == AgentStatus.RUNNING:
+                center = self.query_one(CenterPanel)
+                panel = center.get_orchestrator_panel()
+                if panel and panel.agent_terminal:
+                    self._orchestrator_state.last_output_time = panel.agent_terminal.last_output_time
+            self.query_one(WorktreeList).update_orchestrator_state(self._orchestrator_state)
+            return
+
         state = self._get_agent_state(event.worktree_path)
         state.status = event.status
         state.confidence = event.confidence
@@ -240,6 +261,25 @@ class LazyAgent(App):
         self.query_one(WorktreeList).update_agent_state(event.worktree_path, state)
 
     async def on_agent_exited(self, event: AgentExited) -> None:
+        if event.worktree_path == ORCHESTRATOR_KEY:
+            self._orchestrator_state.status = AgentStatus.NO_AGENT
+            self._orchestrator_state.confidence = LifecycleConfidence.LOW
+            self._orchestrator_state.detail = ""
+            self._orchestrator_state.last_output_time = None
+            self.query_one(WorktreeList).update_orchestrator_state(self._orchestrator_state)
+
+            center = self.query_one(CenterPanel)
+            panel = center.get_orchestrator_panel()
+            if panel is not None:
+                await panel.cleanup_agent()
+
+            self.notify(
+                "Orchestrator exited — press s to spawn again",
+                severity="warning",
+                timeout=5,
+            )
+            return
+
         state = self._get_agent_state(event.worktree_path)
         state.status = AgentStatus.NO_AGENT
         state.confidence = LifecycleConfidence.LOW
@@ -263,6 +303,13 @@ class LazyAgent(App):
     def _check_hangs(self) -> None:
         """Periodic timer callback: check all active agents for hangs."""
         center = self.query_one(CenterPanel)
+
+        # Check orchestrator
+        if self._orchestrator_state.status == AgentStatus.RUNNING:
+            orch_panel = center.get_orchestrator_panel()
+            if orch_panel and orch_panel.agent_terminal:
+                orch_panel.agent_terminal.check_hang()
+
         for worktree_path, state in self._agent_states.items():
             if state.status == AgentStatus.RUNNING:
                 panel = center.get_panel(worktree_path)
@@ -272,6 +319,10 @@ class LazyAgent(App):
     # --- Actions ---
 
     def action_spawn_agent(self) -> None:
+        if self._orchestrator_selected:
+            self._spawn_orchestrator_agent()
+            return
+
         worktree = self._get_selected_worktree()
         if worktree is None:
             self.notify("No worktree selected", severity="warning")
@@ -298,7 +349,34 @@ class LazyAgent(App):
 
         self.push_screen(SpawnModal(worktree.display_label, agent_provider=self._config.agent.provider), on_spawn_dismiss)
 
+    def _spawn_orchestrator_agent(self) -> None:
+        """Spawn agent in the orchestrator panel."""
+        center = self.query_one(CenterPanel)
+        orch_panel = center.get_orchestrator_panel()
+        if orch_panel and orch_panel.has_agent:
+            self.notify("Orchestrator agent already running", severity="warning")
+            return
+
+        async def on_spawn_dismiss(result: SpawnResult | None) -> None:
+            if result is not None:
+                center = self.query_one(CenterPanel)
+                panel = center.switch_to_orchestrator()
+                await panel.spawn_agent(
+                    worktree_path=self._repo_root,
+                    skip_permissions=result.skip_permissions,
+                    agent_provider=self._config.agent.provider,
+                    resume_mode=result.resume_mode,
+                    socket_path=self._ipc_socket_path,
+                    instruction=result.instruction,
+                )
+
+        self.push_screen(SpawnModal("Orchestrator", agent_provider=self._config.agent.provider), on_spawn_dismiss)
+
     async def action_stop_agent(self) -> None:
+        if self._orchestrator_selected:
+            await self._stop_orchestrator_agent()
+            return
+
         worktree = self._get_selected_worktree()
         if worktree is None:
             self.notify("No worktree selected", severity="warning")
@@ -318,10 +396,32 @@ class LazyAgent(App):
         await panel.cleanup_agent()
         self.notify("Agent stopped")
 
+    async def _stop_orchestrator_agent(self) -> None:
+        """Stop the orchestrator agent."""
+        center = self.query_one(CenterPanel)
+        panel = center.get_orchestrator_panel()
+        if panel is None or not panel.has_agent:
+            self.notify("No running orchestrator agent", severity="warning")
+            return
+
+        self._orchestrator_state.status = AgentStatus.NO_AGENT
+        self._orchestrator_state.last_output_time = None
+        self.query_one(WorktreeList).update_orchestrator_state(self._orchestrator_state)
+        await panel.cleanup_agent()
+        self.notify("Orchestrator agent stopped")
+
     def action_focus_sidebar(self) -> None:
         self.query_one(WorktreeList).focus()
 
     def action_focus_agent(self) -> None:
+        if self._orchestrator_selected:
+            panel = self.query_one(CenterPanel).get_orchestrator_panel()
+            if panel and panel.agent_terminal:
+                panel.agent_terminal.focus()
+            else:
+                self.action_spawn_agent()
+            return
+
         wt = self._get_selected_worktree()
         if not wt:
             return

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -11,6 +11,7 @@ from textual.widgets import Footer, Header
 from textual import work
 
 from lazyagent.config import Config, format_command, load_config
+from lazyagent.orchestrator_prompt import compose_orchestrator_prompt
 from lazyagent.ipc import IpcServer, start_ipc_server
 from lazyagent.messages import AgentExited, AgentStatusChanged
 from lazyagent.models import AgentState, AgentStatus, GitStatus, LifecycleConfidence, WorktreeInfo
@@ -322,6 +323,8 @@ class LazyAgent(App):
             self.notify("Orchestrator agent already running", severity="warning")
             return
 
+        orch_prompt = compose_orchestrator_prompt(self._config, self._repo_root)
+
         async def on_spawn_dismiss(result: SpawnResult | None) -> None:
             if result is not None:
                 center = self.query_one(CenterPanel)
@@ -332,6 +335,7 @@ class LazyAgent(App):
                     resume_mode=result.resume_mode,
                     socket_path=self._ipc_socket_path,
                     instruction=result.instruction,
+                    system_prompt=orch_prompt,
                 )
 
         self.push_screen(SpawnModal("Orchestrator", agent_provider=self._config.agent.provider), on_spawn_dismiss)

--- a/src/lazyagent/config.py
+++ b/src/lazyagent/config.py
@@ -37,11 +37,20 @@ class AgentConfig:
 
 
 @dataclass
+class OrchestratorConfig:
+    """Configuration for the orchestrator agent."""
+
+    prompt_file: str | None = None
+    agent_instruction_template: str | None = None
+
+
+@dataclass
 class Config:
     """Application configuration loaded from .lazyagent.toml."""
 
     worktree: WorktreeConfig = field(default_factory=WorktreeConfig)
     agent: AgentConfig = field(default_factory=AgentConfig)
+    orchestrator: OrchestratorConfig = field(default_factory=OrchestratorConfig)
     default_branch: str = DEFAULT_BRANCH
 
     @property
@@ -75,10 +84,16 @@ def load_config(repo_root: str | Path) -> Config:
     )
     agent_data = data.get("agent", {})
     provider = normalize_provider_name(agent_data.get("provider"))
+    orch_data = data.get("orchestrator", {})
+    orchestrator_config = OrchestratorConfig(
+        prompt_file=orch_data.get("prompt_file"),
+        agent_instruction_template=orch_data.get("agent_instruction_template"),
+    )
     default_branch = data.get("default_branch", DEFAULT_BRANCH)
     return Config(
         worktree=worktree_config,
         agent=AgentConfig(provider=provider),
+        orchestrator=orchestrator_config,
         default_branch=default_branch,
     )
 

--- a/src/lazyagent/orchestrator_prompt.py
+++ b/src/lazyagent/orchestrator_prompt.py
@@ -1,0 +1,159 @@
+"""Default system prompt and composition logic for the orchestrator agent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lazyagent.config import Config
+
+DEFAULT_USER_PROMPT_FILE = ".lazyagent-orchestrator.md"
+
+DEFAULT_ORCHESTRATOR_PROMPT = """\
+You are the **lazyagent orchestrator**, a supervisory coding agent that manages \
+parallel workstreams across git worktrees. All coordination happens through MCP \
+tool calls — you never run git commands directly.
+
+## How it works
+
+Each task runs in its own **git worktree** — an isolated checkout of the same \
+repository with its own branch. You create worktrees, spawn agents inside them, \
+monitor progress, and clean up when done.
+
+Agents are **headless coding CLI sessions** (Claude Code, Codex, Gemini CLI) that \
+run inside a terminal. They can read/write files, run commands, and make commits — \
+but only within their own worktree. They cannot see each other.
+
+You are the only one with a global view. Use that to coordinate.
+
+## MCP tool reference
+
+### Worktree management
+
+- **`list_worktrees`** — Returns all worktrees with branch, path, agent status, \
+and git status. Call this first to understand current state.
+- **`create_worktree(branch, base_branch="main")`** — Creates a new worktree on \
+a new branch forked from `base_branch`. Use descriptive branch names \
+(e.g., `fix-auth-redirect`, `add-user-export`).
+- **`remove_worktree(worktree_path, force=false)`** — Removes a worktree. Will \
+fail if an agent is running — stop it first.
+
+### Agent lifecycle
+
+- **`spawn_agent(worktree_path, instruction?)`** — Starts a coding agent in the \
+given worktree. The `instruction` is the task prompt the agent will execute. Make \
+it specific and self-contained — the agent has no context beyond what you write here.
+- **`stop_agent(worktree_path)`** — Kills the agent process. Use when an agent is \
+stuck, went off-track, or the task is done.
+- **`get_agent_status(worktree_path)`** — Returns status (`running`, `waiting`, \
+`idle`, `no_agent`), confidence level, and detail text.
+- **`read_agent_output(worktree_path, lines=50)`** — Reads recent terminal output. \
+Use this to check progress, see errors, or verify completion.
+
+## Workflow
+
+### 1. Assess
+
+Call `list_worktrees` to see what exists, what's running, and what branches are active.
+
+### 2. Plan
+
+For each task the user gives you:
+- Decide: reuse an existing idle worktree, or create a new one?
+- Draft clear, atomic instructions for each agent.
+- Present the plan to the user. Wait for approval before spawning agents.
+
+### 3. Execute
+
+Create worktrees and spawn agents with clear instructions:
+```
+create_worktree(branch="fix-login-bug", base_branch="main")
+spawn_agent(worktree_path="/path/to/worktree", instruction="...")
+```
+
+### 4. Monitor
+
+Poll periodically:
+```
+get_agent_status(worktree_path)  →  is it running? waiting? done?
+read_agent_output(worktree_path)  →  what has it done so far?
+```
+
+If an agent is **waiting for approval** or **stuck**:
+- Read its output to understand the situation.
+- If you can resolve it, stop and re-spawn with refined instructions.
+- If it needs human judgement, escalate to the user.
+
+### 5. Verify & clean up
+
+When an agent finishes:
+- `read_agent_output` to verify the work looks correct.
+- Report the result to the user.
+- Optionally `remove_worktree` if the branch has been merged or is no longer needed.
+
+## Writing good agent instructions
+
+The instruction you pass to `spawn_agent` is the **only context** the agent gets. \
+Make it count:
+
+- **Be specific.** "Fix the login redirect bug in `src/auth/login.py` — the \
+redirect URL is not URL-encoded" is better than "fix the login bug".
+- **Be self-contained.** Include file paths, function names, expected behavior.
+- **One task per agent.** Don't combine unrelated changes.
+- **Include verification.** "Run `pytest tests/test_auth.py` to verify the fix" \
+helps the agent validate its own work.
+
+## Rules
+
+- Always call `list_worktrees` before creating or removing worktrees.
+- Never remove a worktree with a running agent — `stop_agent` first.
+- Never spawn into a worktree that already has a running agent.
+- Prefer reusing existing idle worktrees over creating new ones.
+- Spawn agents sequentially unless the user explicitly asks for parallel execution.
+- When uncertain about scope or approach, ask the user rather than guessing.
+- Keep the user informed of progress at natural milestones (agent spawned, agent \
+finished, error encountered).
+"""
+
+
+def compose_orchestrator_prompt(config: Config, repo_root: str | Path) -> str:
+    """Build the full orchestrator system prompt from all layers.
+
+    Layers (in order):
+    1. Default prompt (always included)
+    2. Agent instruction template section (from config, if set)
+    3. User prompt file content (if the file exists)
+    """
+    parts: list[str] = [DEFAULT_ORCHESTRATOR_PROMPT]
+
+    template_section = _format_template_section(config)
+    if template_section:
+        parts.append(template_section)
+
+    user_prompt = _load_user_prompt(config, repo_root)
+    if user_prompt:
+        parts.append(user_prompt)
+
+    return "\n".join(parts)
+
+
+def _load_user_prompt(config: Config, repo_root: str | Path) -> str | None:
+    """Read the user prompt file from the repo root. Returns None if missing."""
+    filename = config.orchestrator.prompt_file or DEFAULT_USER_PROMPT_FILE
+    path = Path(repo_root) / filename
+    try:
+        return path.read_text(encoding="utf-8").strip() or None
+    except (FileNotFoundError, OSError):
+        return None
+
+
+def _format_template_section(config: Config) -> str | None:
+    """Format the agent instruction template as a prompt section."""
+    template = config.orchestrator.agent_instruction_template
+    if not template:
+        return None
+    return (
+        "## Agent instruction template\n\n"
+        "When spawning agents, use the following template for their instructions "
+        "(substitute placeholders as appropriate):\n\n"
+        f"```\n{template}\n```"
+    )

--- a/src/lazyagent/widgets/center_panel.py
+++ b/src/lazyagent/widgets/center_panel.py
@@ -316,66 +316,58 @@ class CenterPanel(Container):
         )
         yield ContentSwitcher(id="panel-switcher", initial=None)
 
+    def _get_panel_by_key(self, key: str) -> Container | None:
+        """Get an existing panel by key, or None."""
+        if key not in self._panels:
+            return None
+        panel_id = self._panels[key]
+        return self.query_one(f"#{panel_id}", Container)
+
+    def _activate_panel(self, key: str) -> None:
+        """Hide placeholder and switch the ContentSwitcher to the given key."""
+        self.query_one("#center-placeholder", Static).display = False
+        self.query_one("#panel-switcher", ContentSwitcher).current = self._panels[key]
+
     def ensure_panel(self, worktree_path: str) -> WorktreePanel:
         """Get or lazily create a WorktreePanel for the given worktree."""
-        if worktree_path in self._panels:
-            panel_id = self._panels[worktree_path]
-            return self.query_one(f"#{panel_id}", WorktreePanel)
+        existing = self._get_panel_by_key(worktree_path)
+        if existing is not None:
+            return existing  # type: ignore[return-value]
 
         panel_id = _panel_id(worktree_path)
         panel = WorktreePanel(worktree_path, id=panel_id)
-        switcher = self.query_one("#panel-switcher", ContentSwitcher)
-        switcher.mount(panel)
+        self.query_one("#panel-switcher", ContentSwitcher).mount(panel)
         self._panels[worktree_path] = panel_id
         return panel
 
     def switch_to(self, worktree_path: str) -> WorktreePanel:
         """Switch the visible panel to the given worktree (creating if needed)."""
         panel = self.ensure_panel(worktree_path)
-        panel_id = self._panels[worktree_path]
-
-        placeholder = self.query_one("#center-placeholder", Static)
-        placeholder.display = False
-
-        switcher = self.query_one("#panel-switcher", ContentSwitcher)
-        switcher.current = panel_id
+        self._activate_panel(worktree_path)
         return panel
 
     def get_panel(self, worktree_path: str) -> WorktreePanel | None:
-        """Get existing panel or None."""
-        if worktree_path not in self._panels:
-            return None
-        panel_id = self._panels[worktree_path]
-        return self.query_one(f"#{panel_id}", WorktreePanel)
+        """Get existing WorktreePanel or None."""
+        return self._get_panel_by_key(worktree_path)  # type: ignore[return-value]
 
-    def ensure_orchestrator_panel(self) -> OrchestratorPanel:
+    def ensure_orchestrator_panel(self, repo_root: str) -> OrchestratorPanel:
         """Get or lazily create the OrchestratorPanel."""
-        if ORCHESTRATOR_KEY in self._panels:
-            panel_id = self._panels[ORCHESTRATOR_KEY]
-            return self.query_one(f"#{panel_id}", OrchestratorPanel)
+        existing = self._get_panel_by_key(ORCHESTRATOR_KEY)
+        if existing is not None:
+            return existing  # type: ignore[return-value]
 
         panel_id = "wp-orchestrator"
-        panel = OrchestratorPanel(id=panel_id)
-        switcher = self.query_one("#panel-switcher", ContentSwitcher)
-        switcher.mount(panel)
+        panel = OrchestratorPanel(worktree_path=repo_root, id=panel_id)
+        self.query_one("#panel-switcher", ContentSwitcher).mount(panel)
         self._panels[ORCHESTRATOR_KEY] = panel_id
         return panel
 
-    def switch_to_orchestrator(self) -> OrchestratorPanel:
+    def switch_to_orchestrator(self, repo_root: str) -> OrchestratorPanel:
         """Switch the visible panel to the orchestrator."""
-        panel = self.ensure_orchestrator_panel()
-        panel_id = self._panels[ORCHESTRATOR_KEY]
-
-        placeholder = self.query_one("#center-placeholder", Static)
-        placeholder.display = False
-
-        switcher = self.query_one("#panel-switcher", ContentSwitcher)
-        switcher.current = panel_id
+        panel = self.ensure_orchestrator_panel(repo_root)
+        self._activate_panel(ORCHESTRATOR_KEY)
         return panel
 
     def get_orchestrator_panel(self) -> OrchestratorPanel | None:
         """Get the orchestrator panel if it exists."""
-        if ORCHESTRATOR_KEY not in self._panels:
-            return None
-        panel_id = self._panels[ORCHESTRATOR_KEY]
-        return self.query_one(f"#{panel_id}", OrchestratorPanel)
+        return self._get_panel_by_key(ORCHESTRATOR_KEY)  # type: ignore[return-value]

--- a/src/lazyagent/widgets/center_panel.py
+++ b/src/lazyagent/widgets/center_panel.py
@@ -16,6 +16,7 @@ from lazyagent.agent_providers import (
 from lazyagent.models import GitStatus
 from lazyagent.styles import SCROLLBAR_CSS
 from lazyagent.widgets.monitored_terminal import MonitoredTerminal
+from lazyagent.widgets.orchestrator_panel import ORCHESTRATOR_KEY, OrchestratorPanel
 from lazyagent.widgets.scrollable_terminal import ScrollableTerminal
 
 
@@ -346,3 +347,35 @@ class CenterPanel(Container):
             return None
         panel_id = self._panels[worktree_path]
         return self.query_one(f"#{panel_id}", WorktreePanel)
+
+    def ensure_orchestrator_panel(self) -> OrchestratorPanel:
+        """Get or lazily create the OrchestratorPanel."""
+        if ORCHESTRATOR_KEY in self._panels:
+            panel_id = self._panels[ORCHESTRATOR_KEY]
+            return self.query_one(f"#{panel_id}", OrchestratorPanel)
+
+        panel_id = "wp-orchestrator"
+        panel = OrchestratorPanel(id=panel_id)
+        switcher = self.query_one("#panel-switcher", ContentSwitcher)
+        switcher.mount(panel)
+        self._panels[ORCHESTRATOR_KEY] = panel_id
+        return panel
+
+    def switch_to_orchestrator(self) -> OrchestratorPanel:
+        """Switch the visible panel to the orchestrator."""
+        panel = self.ensure_orchestrator_panel()
+        panel_id = self._panels[ORCHESTRATOR_KEY]
+
+        placeholder = self.query_one("#center-placeholder", Static)
+        placeholder.display = False
+
+        switcher = self.query_one("#panel-switcher", ContentSwitcher)
+        switcher.current = panel_id
+        return panel
+
+    def get_orchestrator_panel(self) -> OrchestratorPanel | None:
+        """Get the orchestrator panel if it exists."""
+        if ORCHESTRATOR_KEY not in self._panels:
+            return None
+        panel_id = self._panels[ORCHESTRATOR_KEY]
+        return self.query_one(f"#{panel_id}", OrchestratorPanel)

--- a/src/lazyagent/widgets/orchestrator_panel.py
+++ b/src/lazyagent/widgets/orchestrator_panel.py
@@ -69,6 +69,7 @@ class OrchestratorPanel(Container):
         resume_mode: ResumeMode = ResumeMode.NEW,
         socket_path: str | None = None,
         instruction: str | None = None,
+        system_prompt: str | None = None,
     ) -> None:
         """Spawn the orchestrator agent process."""
         # Remove previous terminal or placeholder
@@ -93,6 +94,7 @@ class OrchestratorPanel(Container):
             runtime_context=runtime_context,
             resume_mode=resume_mode,
             instruction=instruction,
+            system_prompt=system_prompt,
         )
 
         terminal = MonitoredTerminal(

--- a/src/lazyagent/widgets/orchestrator_panel.py
+++ b/src/lazyagent/widgets/orchestrator_panel.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from textual.containers import Container
+from textual.widgets import Static
+
+from lazyagent.agent_providers import (
+    DEFAULT_AGENT_PROVIDER,
+    ResumeMode,
+    env_exports,
+    get_agent_provider,
+)
+from lazyagent.widgets.monitored_terminal import MonitoredTerminal
+
+ORCHESTRATOR_KEY = "__orchestrator__"
+
+
+class OrchestratorPanel(Container):
+    """Simplified center panel for the orchestrator — just a single MonitoredTerminal."""
+
+    DEFAULT_CSS = """
+    OrchestratorPanel {
+        layout: vertical;
+        width: 1fr;
+        height: 1fr;
+    }
+    #orch-placeholder {
+        width: 1fr;
+        height: 1fr;
+        content-align: center middle;
+        color: $text-muted;
+    }
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._agent_terminal: MonitoredTerminal | None = None
+
+    def compose(self):
+        yield Static(
+            "Press [bold]s[/bold] to spawn orchestrator",
+            id="orch-placeholder",
+        )
+
+    @property
+    def agent_terminal(self) -> MonitoredTerminal | None:
+        return self._agent_terminal
+
+    @property
+    def has_agent(self) -> bool:
+        return (
+            self._agent_terminal is not None
+            and self._agent_terminal.emulator is not None
+        )
+
+    async def cleanup_agent(self) -> None:
+        """Remove the agent terminal and restore the placeholder."""
+        if self._agent_terminal is not None:
+            self._agent_terminal.stop()
+            await self._agent_terminal.remove()
+            self._agent_terminal = None
+
+        try:
+            self.query_one("#orch-placeholder")
+        except Exception:
+            self.mount(
+                Static(
+                    "Press [bold]s[/bold] to spawn orchestrator",
+                    id="orch-placeholder",
+                )
+            )
+
+    async def spawn_agent(
+        self,
+        worktree_path: str,
+        skip_permissions: bool = False,
+        agent_provider: str = DEFAULT_AGENT_PROVIDER,
+        resume_mode: ResumeMode = ResumeMode.NEW,
+        socket_path: str | None = None,
+        instruction: str | None = None,
+    ) -> None:
+        """Spawn the orchestrator agent process."""
+        # Remove previous terminal or placeholder
+        if self._agent_terminal is not None:
+            self._agent_terminal.stop()
+            await self._agent_terminal.remove()
+            self._agent_terminal = None
+
+        try:
+            placeholder = self.query_one("#orch-placeholder", Static)
+            await placeholder.remove()
+        except Exception:
+            pass
+
+        provider = get_agent_provider(agent_provider)
+        runtime_context = provider.build_runtime_context(
+            worktree_path, socket_path=socket_path
+        )
+        command = provider.build_command(
+            worktree_path,
+            skip_permissions=skip_permissions,
+            runtime_context=runtime_context,
+            resume_mode=resume_mode,
+            instruction=instruction,
+        )
+
+        terminal = MonitoredTerminal(
+            command=command,
+            worktree_path=ORCHESTRATOR_KEY,
+            observer=provider.create_observer_from_context(runtime_context),
+            id="orch-agent-terminal",
+        )
+        self._agent_terminal = terminal
+        self.mount(terminal)
+        terminal.start()
+        terminal.focus()

--- a/src/lazyagent/widgets/orchestrator_panel.py
+++ b/src/lazyagent/widgets/orchestrator_panel.py
@@ -6,12 +6,12 @@ from textual.widgets import Static
 from lazyagent.agent_providers import (
     DEFAULT_AGENT_PROVIDER,
     ResumeMode,
-    env_exports,
     get_agent_provider,
 )
 from lazyagent.widgets.monitored_terminal import MonitoredTerminal
 
 ORCHESTRATOR_KEY = "__orchestrator__"
+_PLACEHOLDER_TEXT = "Press [bold]s[/bold] to spawn orchestrator"
 
 
 class OrchestratorPanel(Container):
@@ -31,15 +31,13 @@ class OrchestratorPanel(Container):
     }
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, worktree_path: str, **kwargs) -> None:
         super().__init__(**kwargs)
+        self.worktree_path = worktree_path
         self._agent_terminal: MonitoredTerminal | None = None
 
     def compose(self):
-        yield Static(
-            "Press [bold]s[/bold] to spawn orchestrator",
-            id="orch-placeholder",
-        )
+        yield Static(_PLACEHOLDER_TEXT, id="orch-placeholder")
 
     @property
     def agent_terminal(self) -> MonitoredTerminal | None:
@@ -62,16 +60,10 @@ class OrchestratorPanel(Container):
         try:
             self.query_one("#orch-placeholder")
         except Exception:
-            self.mount(
-                Static(
-                    "Press [bold]s[/bold] to spawn orchestrator",
-                    id="orch-placeholder",
-                )
-            )
+            self.mount(Static(_PLACEHOLDER_TEXT, id="orch-placeholder"))
 
     async def spawn_agent(
         self,
-        worktree_path: str,
         skip_permissions: bool = False,
         agent_provider: str = DEFAULT_AGENT_PROVIDER,
         resume_mode: ResumeMode = ResumeMode.NEW,
@@ -93,10 +85,10 @@ class OrchestratorPanel(Container):
 
         provider = get_agent_provider(agent_provider)
         runtime_context = provider.build_runtime_context(
-            worktree_path, socket_path=socket_path
+            self.worktree_path, socket_path=socket_path
         )
         command = provider.build_command(
-            worktree_path,
+            self.worktree_path,
             skip_permissions=skip_permissions,
             runtime_context=runtime_context,
             resume_mode=resume_mode,

--- a/src/lazyagent/widgets/worktree_list.py
+++ b/src/lazyagent/widgets/worktree_list.py
@@ -4,6 +4,78 @@ from textual.binding import Binding
 from textual.widgets import ListItem, ListView, Static
 
 from lazyagent.models import AgentState, AgentStatus, GitStatus, LifecycleConfidence, WorktreeInfo
+from lazyagent.widgets.orchestrator_panel import ORCHESTRATOR_KEY
+
+
+class OrchestratorListItem(ListItem):
+    """Special first entry in the sidebar for the orchestrator agent."""
+
+    DEFAULT_CSS = """
+    OrchestratorListItem {
+        height: 2;
+        padding: 0 1;
+        color: $text;
+        background: $primary-background-darken-1;
+        border-left: tall $warning;
+    }
+    OrchestratorListItem.-highlight {
+        background: $boost;
+    }
+    """
+
+    def __init__(self, agent_state: AgentState | None = None) -> None:
+        super().__init__()
+        self._agent_state = agent_state or AgentState()
+
+    def compose(self):
+        yield Static(self._build_label(), markup=True, id="orch-label")
+
+    def _build_label(self) -> str:
+        status = self._status_line()
+        return f"[bold]ORCH[/bold]\n{status}"
+
+    def _status_line(self) -> str:
+        state = self._agent_state
+        status = state.status
+        conf = state.confidence
+
+        def _fmt(text: str, color: str) -> str:
+            if conf == LifecycleConfidence.LOW:
+                return f"[dim {color}]{text}[/dim {color}]"
+            return f"[{color}]{text}[/{color}]"
+
+        if status == AgentStatus.NO_AGENT:
+            return "[dim]---[/dim]"
+
+        res = ""
+        if status == AgentStatus.RUNNING:
+            res = _fmt("running", "green")
+        elif status in (AgentStatus.WAITING, AgentStatus.WAITING_FOR_USER):
+            res = _fmt("waiting", "bold yellow")
+        elif status == AgentStatus.WAITING_FOR_APPROVAL:
+            res = _fmt("approving", "bold yellow")
+        elif status == AgentStatus.COMPLETED:
+            res = _fmt("completed", "bold cyan")
+        elif status == AgentStatus.FAILED:
+            res = _fmt("failed", "bold red")
+        elif status == AgentStatus.INTERRUPTED:
+            res = _fmt("interrupted", "dim red")
+        elif status == AgentStatus.POSSIBLY_HANGED:
+            res = "[bold red]hanged?[/bold red]"
+
+        if state.detail and status not in (AgentStatus.RUNNING, AgentStatus.NO_AGENT):
+            res += f" [dim]({state.detail})[/dim]"
+
+        return res or "[dim]---[/dim]"
+
+    def update_agent_state(self, state: AgentState) -> None:
+        """Re-render the label with updated agent state."""
+        self._agent_state = state
+        try:
+            label_widget = self.query_one("#orch-label", Static)
+            label_widget.update(self._build_label())
+        except Exception:
+            pass
 
 
 class WorktreeListItem(ListItem):
@@ -139,9 +211,17 @@ class WorktreeList(ListView):
         """Replace the list contents with the given worktrees, restoring agent state if provided."""
         self.clear()
         agent_states = agent_states or {}
+        self.append(OrchestratorListItem(agent_state=agent_states.get(ORCHESTRATOR_KEY)))
         for wt in worktrees:
             state = agent_states.get(wt.path)
             self.append(WorktreeListItem(wt, agent_state=state))
+
+    def update_orchestrator_state(self, state: AgentState) -> None:
+        """Update the orchestrator list item's agent state."""
+        for child in self.children:
+            if isinstance(child, OrchestratorListItem):
+                child.update_agent_state(state)
+                break
 
     def update_agent_state(self, worktree_path: str, state: AgentState) -> None:
         """Find the item for the given worktree path and update its agent state."""

--- a/src/lazyagent/widgets/worktree_list.py
+++ b/src/lazyagent/widgets/worktree_list.py
@@ -7,6 +7,41 @@ from lazyagent.models import AgentState, AgentStatus, GitStatus, LifecycleConfid
 from lazyagent.widgets.orchestrator_panel import ORCHESTRATOR_KEY
 
 
+def format_agent_status(state: AgentState) -> str:
+    """Format an AgentState into a Rich-markup status string."""
+    status = state.status
+    conf = state.confidence
+
+    def _fmt(text: str, color: str) -> str:
+        if conf == LifecycleConfidence.LOW:
+            return f"[dim {color}]{text}[/dim {color}]"
+        return f"[{color}]{text}[/{color}]"
+
+    if status == AgentStatus.NO_AGENT:
+        return "[dim]---[/dim]"
+
+    res = ""
+    if status == AgentStatus.RUNNING:
+        res = _fmt("running", "green")
+    elif status in (AgentStatus.WAITING, AgentStatus.WAITING_FOR_USER):
+        res = _fmt("waiting", "bold yellow")
+    elif status == AgentStatus.WAITING_FOR_APPROVAL:
+        res = _fmt("approving", "bold yellow")
+    elif status == AgentStatus.COMPLETED:
+        res = _fmt("completed", "bold cyan")
+    elif status == AgentStatus.FAILED:
+        res = _fmt("failed", "bold red")
+    elif status == AgentStatus.INTERRUPTED:
+        res = _fmt("interrupted", "dim red")
+    elif status == AgentStatus.POSSIBLY_HANGED:
+        res = "[bold red]hanged?[/bold red]"
+
+    if state.detail and status not in (AgentStatus.RUNNING, AgentStatus.NO_AGENT):
+        res += f" [dim]({state.detail})[/dim]"
+
+    return res or "[dim]---[/dim]"
+
+
 class OrchestratorListItem(ListItem):
     """Special first entry in the sidebar for the orchestrator agent."""
 
@@ -31,42 +66,7 @@ class OrchestratorListItem(ListItem):
         yield Static(self._build_label(), markup=True, id="orch-label")
 
     def _build_label(self) -> str:
-        status = self._status_line()
-        return f"[bold]ORCH[/bold]\n{status}"
-
-    def _status_line(self) -> str:
-        state = self._agent_state
-        status = state.status
-        conf = state.confidence
-
-        def _fmt(text: str, color: str) -> str:
-            if conf == LifecycleConfidence.LOW:
-                return f"[dim {color}]{text}[/dim {color}]"
-            return f"[{color}]{text}[/{color}]"
-
-        if status == AgentStatus.NO_AGENT:
-            return "[dim]---[/dim]"
-
-        res = ""
-        if status == AgentStatus.RUNNING:
-            res = _fmt("running", "green")
-        elif status in (AgentStatus.WAITING, AgentStatus.WAITING_FOR_USER):
-            res = _fmt("waiting", "bold yellow")
-        elif status == AgentStatus.WAITING_FOR_APPROVAL:
-            res = _fmt("approving", "bold yellow")
-        elif status == AgentStatus.COMPLETED:
-            res = _fmt("completed", "bold cyan")
-        elif status == AgentStatus.FAILED:
-            res = _fmt("failed", "bold red")
-        elif status == AgentStatus.INTERRUPTED:
-            res = _fmt("interrupted", "dim red")
-        elif status == AgentStatus.POSSIBLY_HANGED:
-            res = "[bold red]hanged?[/bold red]"
-
-        if state.detail and status not in (AgentStatus.RUNNING, AgentStatus.NO_AGENT):
-            res += f" [dim]({state.detail})[/dim]"
-
-        return res or "[dim]---[/dim]"
+        return f"[bold]ORCH[/bold]\n{format_agent_status(self._agent_state)}"
 
     def update_agent_state(self, state: AgentState) -> None:
         """Re-render the label with updated agent state."""
@@ -110,44 +110,9 @@ class WorktreeListItem(ListItem):
     def _build_label(self) -> str:
         label = self.worktree.display_label
         branch = self.worktree.display_branch
-        status = self._status_line()
+        status = format_agent_status(self._agent_state)
         git = self._git_status_line()
         return f"[bold]{label}[/bold]\n{branch}\n{status}\n{git}"
-
-    def _status_line(self) -> str:
-        state = self._agent_state
-        status = state.status
-        conf = state.confidence
-        detail = state.detail
-
-        def _fmt(text: str, color: str) -> str:
-            if conf == LifecycleConfidence.LOW:
-                return f"[dim {color}]{text}[/dim {color}]"
-            return f"[{color}]{text}[/{color}]"
-
-        if status == AgentStatus.NO_AGENT:
-            return "[dim]---[/dim]"
-
-        res = ""
-        if status == AgentStatus.RUNNING:
-            res = _fmt("running", "green")
-        elif status in (AgentStatus.WAITING, AgentStatus.WAITING_FOR_USER):
-            res = _fmt("waiting", "bold yellow")
-        elif status == AgentStatus.WAITING_FOR_APPROVAL:
-            res = _fmt("approving", "bold yellow")
-        elif status == AgentStatus.COMPLETED:
-            res = _fmt("completed", "bold cyan")
-        elif status == AgentStatus.FAILED:
-            res = _fmt("failed", "bold red")
-        elif status == AgentStatus.INTERRUPTED:
-            res = _fmt("interrupted", "dim red")
-        elif status == AgentStatus.POSSIBLY_HANGED:
-            res = "[bold red]hanged?[/bold red]"
-
-        if detail and status not in (AgentStatus.RUNNING, AgentStatus.NO_AGENT):
-            res += f" [dim]({detail})[/dim]"
-
-        return res or "[dim]---[/dim]"
 
     def _git_status_line(self) -> str:
         gs = self._git_status
@@ -216,19 +181,18 @@ class WorktreeList(ListView):
             state = agent_states.get(wt.path)
             self.append(WorktreeListItem(wt, agent_state=state))
 
-    def update_orchestrator_state(self, state: AgentState) -> None:
-        """Update the orchestrator list item's agent state."""
-        for child in self.children:
-            if isinstance(child, OrchestratorListItem):
-                child.update_agent_state(state)
-                break
-
-    def update_agent_state(self, worktree_path: str, state: AgentState) -> None:
-        """Find the item for the given worktree path and update its agent state."""
-        for child in self.children:
-            if isinstance(child, WorktreeListItem) and child.worktree.path == worktree_path:
-                child.update_agent_state(state)
-                break
+    def update_agent_state(self, key: str, state: AgentState) -> None:
+        """Update the sidebar item for the given key (worktree path or ORCHESTRATOR_KEY)."""
+        if key == ORCHESTRATOR_KEY:
+            for child in self.children:
+                if isinstance(child, OrchestratorListItem):
+                    child.update_agent_state(state)
+                    break
+        else:
+            for child in self.children:
+                if isinstance(child, WorktreeListItem) and child.worktree.path == key:
+                    child.update_agent_state(state)
+                    break
 
     def update_all_git_statuses(self, statuses: dict[str, GitStatus]) -> None:
         """Bulk update git status on all items."""

--- a/tests/test_agent_providers.py
+++ b/tests/test_agent_providers.py
@@ -221,6 +221,71 @@ class TestBuildCommandResume:
         assert "--resume" not in script
 
 
+class TestBuildCommandSystemPrompt:
+    def test_claude_uses_append_system_prompt_flag(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command(
+                "/tmp/wt", system_prompt="You are the orchestrator."
+            )
+        )[2]
+        assert "--append-system-prompt" in script
+        assert "You are the orchestrator." in script
+
+    def test_claude_no_system_prompt_no_flag(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command("/tmp/wt")
+        )[2]
+        assert "--append-system-prompt" not in script
+
+    def test_claude_none_system_prompt_no_flag(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command("/tmp/wt", system_prompt=None)
+        )[2]
+        assert "--append-system-prompt" not in script
+
+    def test_codex_prepends_system_prompt_to_instruction(self):
+        script = shlex.split(
+            get_agent_provider("codex").build_command(
+                "/tmp/wt",
+                instruction="do stuff",
+                system_prompt="You are the orchestrator.",
+            )
+        )[2]
+        # Codex has no system_prompt_flag, so prompt is prepended to instruction
+        assert "--append-system-prompt" not in script
+        assert "You are the orchestrator." in script
+        assert "do stuff" in script
+
+    def test_codex_system_prompt_without_instruction(self):
+        script = shlex.split(
+            get_agent_provider("codex").build_command(
+                "/tmp/wt", system_prompt="You are the orchestrator."
+            )
+        )[2]
+        assert "You are the orchestrator." in script
+
+    def test_gemini_prepends_system_prompt_to_instruction(self):
+        script = shlex.split(
+            get_agent_provider("gemini").build_command(
+                "/tmp/wt",
+                instruction="hello",
+                system_prompt="You are the orchestrator.",
+            )
+        )[2]
+        assert "-i" in script
+        assert "You are the orchestrator." in script
+        assert "hello" in script
+
+    def test_gemini_system_prompt_without_instruction(self):
+        script = shlex.split(
+            get_agent_provider("gemini").build_command(
+                "/tmp/wt", system_prompt="You are the orchestrator."
+            )
+        )[2]
+        assert "-i" in script
+        assert "You are the orchestrator." in script
+
+
 class TestBuildCommandInstruction:
     def test_claude_instruction_as_positional_arg(self):
         script = shlex.split(

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -94,7 +94,8 @@ def _select_worktree(app: LazyAgent, index: int) -> WorktreeInfo:
         for child in worktree_list.children
         if isinstance(child, WorktreeListItem)
     ][index]
-    worktree_list.index = index
+    # +1 to account for the OrchestratorListItem at position 0
+    worktree_list.index = index + 1
     app.on_list_view_highlighted(WorktreeList.Highlighted(worktree_list, item))
     return item.worktree
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from lazyagent.config import Config, WorktreeConfig, format_command, load_config
+from lazyagent.config import Config, OrchestratorConfig, WorktreeConfig, format_command, load_config
 
 
 class TestLoadConfig:
@@ -78,6 +78,39 @@ provider = "other"
         (tmp_path / ".lazyagent.toml").write_text("[worktree]\n")
         config = load_config(tmp_path)
         assert config.default_branch == "master"
+
+    def test_orchestrator_defaults(self, tmp_path: Path):
+        config = load_config(tmp_path)
+        assert config.orchestrator.prompt_file is None
+        assert config.orchestrator.agent_instruction_template is None
+
+    def test_orchestrator_prompt_file(self, tmp_path: Path):
+        toml_content = """\
+[orchestrator]
+prompt_file = "my-prompt.md"
+"""
+        (tmp_path / ".lazyagent.toml").write_text(toml_content)
+        config = load_config(tmp_path)
+        assert config.orchestrator.prompt_file == "my-prompt.md"
+
+    def test_orchestrator_agent_instruction_template(self, tmp_path: Path):
+        toml_content = """\
+[orchestrator]
+agent_instruction_template = "/clickup-fix-card {task_id}"
+"""
+        (tmp_path / ".lazyagent.toml").write_text(toml_content)
+        config = load_config(tmp_path)
+        assert config.orchestrator.agent_instruction_template == "/clickup-fix-card {task_id}"
+
+    def test_orchestrator_partial_config(self, tmp_path: Path):
+        toml_content = """\
+[orchestrator]
+prompt_file = "custom.md"
+"""
+        (tmp_path / ".lazyagent.toml").write_text(toml_content)
+        config = load_config(tmp_path)
+        assert config.orchestrator.prompt_file == "custom.md"
+        assert config.orchestrator.agent_instruction_template is None
 
 
 class TestConfigProperties:

--- a/tests/test_orchestrator_panel.py
+++ b/tests/test_orchestrator_panel.py
@@ -222,7 +222,7 @@ async def test_orchestrator_status_changed_updates_sidebar(monkeypatch):
         app.on_agent_status_changed(event)
         await pilot.pause()
 
-        assert app._orchestrator_state.status == AgentStatus.RUNNING
+        assert app._get_agent_state(ORCHESTRATOR_KEY).status == AgentStatus.RUNNING
 
         # Verify sidebar was updated
         wt_list = app.query_one(WorktreeList)
@@ -240,14 +240,14 @@ async def test_orchestrator_exited_resets_state(monkeypatch):
         from lazyagent.messages import AgentExited
 
         # Set running state first
-        app._orchestrator_state.status = AgentStatus.RUNNING
+        app._get_agent_state(ORCHESTRATOR_KEY).status = AgentStatus.RUNNING
 
         app.notify = MagicMock()
         event = AgentExited(worktree_path=ORCHESTRATOR_KEY)
         await app.on_agent_exited(event)
         await pilot.pause()
 
-        assert app._orchestrator_state.status == AgentStatus.NO_AGENT
+        assert app._get_agent_state(ORCHESTRATOR_KEY).status == AgentStatus.NO_AGENT
         app.notify.assert_called_once()
         assert "Orchestrator exited" in app.notify.call_args.args[0]
 

--- a/tests/test_orchestrator_panel.py
+++ b/tests/test_orchestrator_panel.py
@@ -1,0 +1,271 @@
+"""Tests for orchestrator panel UI integration."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from lazyagent.app import LazyAgent
+from lazyagent.config import Config
+from lazyagent.models import AgentState, AgentStatus, GitStatus, LifecycleConfidence, WorktreeInfo
+from lazyagent.widgets.center_panel import CenterPanel
+from lazyagent.widgets.orchestrator_panel import ORCHESTRATOR_KEY, OrchestratorPanel
+from lazyagent.widgets.worktree_list import OrchestratorListItem, WorktreeList, WorktreeListItem
+from lazyagent.widgets.center_panel import WorktreePanel
+
+
+MAIN_WORKTREE = WorktreeInfo(
+    path="/repo",
+    head="a" * 40,
+    branch="main",
+    is_main=True,
+    is_bare=False,
+)
+
+FEATURE_WORKTREE = WorktreeInfo(
+    path="/repo-feature",
+    head="b" * 40,
+    branch="feature/demo",
+    is_main=False,
+    is_bare=False,
+)
+
+WORKTREES = [MAIN_WORKTREE, FEATURE_WORKTREE]
+
+
+class DummyWorktreeManager:
+    def __init__(self, repo_path):
+        self.repo_path = Path(repo_path)
+
+    def list(self):
+        return WORKTREES
+
+    def get_all_git_statuses(self, worktrees):
+        return {wt.path: GitStatus() for wt in worktrees}
+
+    @staticmethod
+    def get_diff(worktree_path):
+        return ""
+
+    @staticmethod
+    def is_gh_available():
+        return False
+
+
+def _patch_app(monkeypatch):
+    monkeypatch.setattr("lazyagent.app.WorktreeManager", DummyWorktreeManager)
+    monkeypatch.setattr("lazyagent.app.load_config", lambda repo_root: Config())
+    monkeypatch.setattr(WorktreePanel, "_try_start_terminal", lambda self: None)
+    monkeypatch.setattr(LazyAgent, "_refresh_pr_status", lambda self: None)
+
+
+# --- OrchestratorListItem unit tests ---
+
+
+class TestOrchestratorListItem:
+    def test_default_status_shows_dashes(self):
+        item = OrchestratorListItem()
+        label = item._build_label()
+        assert "ORCH" in label
+        assert "---" in label
+
+    def test_running_status_shows_running(self):
+        state = AgentState(status=AgentStatus.RUNNING, confidence=LifecycleConfidence.HIGH)
+        item = OrchestratorListItem(agent_state=state)
+        label = item._build_label()
+        assert "running" in label
+
+    def test_update_agent_state_changes_label(self):
+        item = OrchestratorListItem()
+        assert "---" in item._build_label()
+        item.update_agent_state(
+            AgentState(status=AgentStatus.WAITING, confidence=LifecycleConfidence.HIGH)
+        )
+        assert "waiting" in item._build_label()
+
+
+# --- WorktreeList orchestrator prepend (tested via app integration below) ---
+
+
+# --- CenterPanel orchestrator methods ---
+
+
+class TestCenterPanelOrchestrator:
+    def test_ensure_orchestrator_panel_creates_panel(self):
+        center = CenterPanel()
+        assert center.get_orchestrator_panel() is None
+        # Can't fully test compose without running app, but verify _panels tracking
+        assert ORCHESTRATOR_KEY not in center._panels
+
+    def test_panel_key_is_deterministic(self):
+        """The orchestrator panel ID is always 'wp-orchestrator'."""
+        center = CenterPanel()
+        # Verify constant
+        assert ORCHESTRATOR_KEY == "__orchestrator__"
+
+
+# --- App integration tests ---
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_is_first_sidebar_entry(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        wt_list = app.query_one(WorktreeList)
+        children = [c for c in wt_list.children if isinstance(c, (OrchestratorListItem, WorktreeListItem))]
+        assert len(children) == 3
+        assert isinstance(children[0], OrchestratorListItem)
+
+
+@pytest.mark.asyncio
+async def test_selecting_orchestrator_switches_to_orchestrator_panel(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        wt_list = app.query_one(WorktreeList)
+        # Select orchestrator (index 0)
+        orch_item = list(wt_list.children)[0]
+        wt_list.index = 0
+        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await pilot.pause()
+
+        assert app._orchestrator_selected is True
+        assert app._selected_worktree is None
+
+        center = app.query_one(CenterPanel)
+        panel = center.get_orchestrator_panel()
+        assert panel is not None
+        assert isinstance(panel, OrchestratorPanel)
+
+
+@pytest.mark.asyncio
+async def test_selecting_worktree_after_orchestrator_clears_flag(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        wt_list = app.query_one(WorktreeList)
+
+        # Select orchestrator
+        orch_item = list(wt_list.children)[0]
+        wt_list.index = 0
+        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await pilot.pause()
+        assert app._orchestrator_selected is True
+
+        # Select worktree
+        wt_item = list(wt_list.children)[1]
+        wt_list.index = 1
+        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, wt_item))
+        await pilot.pause()
+        assert app._orchestrator_selected is False
+        assert app._selected_worktree is not None
+
+
+@pytest.mark.asyncio
+async def test_spawn_on_orchestrator_shows_modal(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        wt_list = app.query_one(WorktreeList)
+
+        # Select orchestrator
+        orch_item = list(wt_list.children)[0]
+        wt_list.index = 0
+        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await pilot.pause()
+
+        # Mock push_screen to verify modal is shown
+        app.push_screen = MagicMock()
+        app.action_spawn_agent()
+        app.push_screen.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_on_orchestrator_without_agent_notifies(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        wt_list = app.query_one(WorktreeList)
+
+        # Select orchestrator
+        orch_item = list(wt_list.children)[0]
+        wt_list.index = 0
+        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await pilot.pause()
+
+        app.notify = MagicMock()
+        await app.action_stop_agent()
+        app.notify.assert_called_once()
+        assert "No running orchestrator" in app.notify.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_status_changed_updates_sidebar(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        from lazyagent.messages import AgentStatusChanged
+
+        event = AgentStatusChanged(
+            worktree_path=ORCHESTRATOR_KEY,
+            status=AgentStatus.RUNNING,
+            confidence=LifecycleConfidence.HIGH,
+        )
+        app.on_agent_status_changed(event)
+        await pilot.pause()
+
+        assert app._orchestrator_state.status == AgentStatus.RUNNING
+
+        # Verify sidebar was updated
+        wt_list = app.query_one(WorktreeList)
+        orch_item = list(wt_list.children)[0]
+        assert isinstance(orch_item, OrchestratorListItem)
+        assert orch_item._agent_state.status == AgentStatus.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_exited_resets_state(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        from lazyagent.messages import AgentExited
+
+        # Set running state first
+        app._orchestrator_state.status = AgentStatus.RUNNING
+
+        app.notify = MagicMock()
+        event = AgentExited(worktree_path=ORCHESTRATOR_KEY)
+        await app.on_agent_exited(event)
+        await pilot.pause()
+
+        assert app._orchestrator_state.status == AgentStatus.NO_AGENT
+        app.notify.assert_called_once()
+        assert "Orchestrator exited" in app.notify.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_ctrl_j_on_orchestrator_triggers_spawn_when_no_agent(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        wt_list = app.query_one(WorktreeList)
+
+        # Select orchestrator
+        orch_item = list(wt_list.children)[0]
+        wt_list.index = 0
+        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await pilot.pause()
+
+        app.action_spawn_agent = MagicMock()
+        app.action_focus_agent()
+        app.action_spawn_agent.assert_called_once()

--- a/tests/test_orchestrator_prompt.py
+++ b/tests/test_orchestrator_prompt.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from lazyagent.config import Config, OrchestratorConfig
+from lazyagent.orchestrator_prompt import (
+    DEFAULT_ORCHESTRATOR_PROMPT,
+    DEFAULT_USER_PROMPT_FILE,
+    compose_orchestrator_prompt,
+)
+
+
+class TestDefaultPrompt:
+    def test_contains_identity(self):
+        assert "orchestrator" in DEFAULT_ORCHESTRATOR_PROMPT.lower()
+
+    def test_contains_mcp_tools(self):
+        for tool in [
+            "list_worktrees",
+            "create_worktree",
+            "remove_worktree",
+            "spawn_agent",
+            "stop_agent",
+            "get_agent_status",
+            "read_agent_output",
+        ]:
+            assert tool in DEFAULT_ORCHESTRATOR_PROMPT
+
+    def test_contains_workflow_phases(self):
+        assert "### 1. Assess" in DEFAULT_ORCHESTRATOR_PROMPT
+        assert "### 3. Execute" in DEFAULT_ORCHESTRATOR_PROMPT
+        assert "### 4. Monitor" in DEFAULT_ORCHESTRATOR_PROMPT
+
+
+class TestComposeOrchestratorPrompt:
+    def test_default_only(self, tmp_path: Path):
+        config = Config()
+        result = compose_orchestrator_prompt(config, tmp_path)
+        assert result == DEFAULT_ORCHESTRATOR_PROMPT
+
+    def test_with_user_prompt_file(self, tmp_path: Path):
+        (tmp_path / DEFAULT_USER_PROMPT_FILE).write_text("Custom user rules here.")
+        config = Config()
+        result = compose_orchestrator_prompt(config, tmp_path)
+        assert DEFAULT_ORCHESTRATOR_PROMPT in result
+        assert "Custom user rules here." in result
+
+    def test_with_custom_prompt_file_path(self, tmp_path: Path):
+        (tmp_path / "my-prompt.md").write_text("My custom prompt.")
+        config = Config(
+            orchestrator=OrchestratorConfig(prompt_file="my-prompt.md")
+        )
+        result = compose_orchestrator_prompt(config, tmp_path)
+        assert "My custom prompt." in result
+
+    def test_missing_user_file_returns_default_only(self, tmp_path: Path):
+        config = Config()
+        result = compose_orchestrator_prompt(config, tmp_path)
+        assert result == DEFAULT_ORCHESTRATOR_PROMPT
+
+    def test_with_template(self, tmp_path: Path):
+        config = Config(
+            orchestrator=OrchestratorConfig(
+                agent_instruction_template="/clickup-fix-card {task_id}"
+            )
+        )
+        result = compose_orchestrator_prompt(config, tmp_path)
+        assert "/clickup-fix-card {task_id}" in result
+        assert "Agent instruction template" in result
+
+    def test_with_template_and_user_file(self, tmp_path: Path):
+        (tmp_path / DEFAULT_USER_PROMPT_FILE).write_text("Extra rules.")
+        config = Config(
+            orchestrator=OrchestratorConfig(
+                agent_instruction_template="/fix {id}"
+            )
+        )
+        result = compose_orchestrator_prompt(config, tmp_path)
+        # All three layers present
+        assert DEFAULT_ORCHESTRATOR_PROMPT in result
+        assert "/fix {id}" in result
+        assert "Extra rules." in result
+        # Template appears before user prompt
+        assert result.index("/fix {id}") < result.index("Extra rules.")
+
+    def test_empty_user_file_ignored(self, tmp_path: Path):
+        (tmp_path / DEFAULT_USER_PROMPT_FILE).write_text("   \n  ")
+        config = Config()
+        result = compose_orchestrator_prompt(config, tmp_path)
+        assert result == DEFAULT_ORCHESTRATOR_PROMPT


### PR DESCRIPTION
## Summary
- Add default orchestrator system prompt with MCP tool docs, workflow phases, and agent instruction guidelines
- Support user-configurable prompt file (`.lazyagent-orchestrator.md`) that augments the default
- Support `agent_instruction_template` config for spawn-time instruction templates
- Wire prompt composition into the orchestrator spawn flow via `--append-system-prompt` (Claude) or instruction prepend (Codex/Gemini)

Closes #27, closes #28, closes #29

## Test plan
- [x] `pytest tests/` — all 322 tests pass (18 new)
- [ ] Manual: launch lazyagent → ORCH → `s` → verify Claude command includes `--append-system-prompt`
- [ ] Manual: create `.lazyagent-orchestrator.md` in repo root → re-spawn → user content appears in prompt
- [ ] Manual: add `[orchestrator] agent_instruction_template = "..."` to `.lazyagent.toml` → template appears in prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)