### PR TITLE
feat: add MCP server and IPC layer for orchestrator (#25)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.4.0"
 description = "A Textual TUI for managing coding agents across git worktrees"
 requires-python = ">=3.10"
 dependencies = [
+    "mcp>=1.0.0",
     "pyte>=0.8.0",
     "textual>=8.0.0",
     "tomli>=2.0.0; python_version < '3.11'",

--- a/src/lazyagent/agent_providers.py
+++ b/src/lazyagent/agent_providers.py
@@ -53,6 +53,7 @@ class AgentProvider:
     resume_pick_args: tuple[str, ...] = ()
     resume_last_args: tuple[str, ...] = ()
     resume_is_subcommand: bool = False
+    instruction_flag: str | None = None
 
     def build_command(
         self,
@@ -60,6 +61,7 @@ class AgentProvider:
         skip_permissions: bool = False,
         runtime_context: ProviderRuntimeContext | None = None,
         resume_mode: ResumeMode = ResumeMode.NEW,
+        instruction: str | None = None,
     ) -> str:
         """Build the full shell command used to launch this provider."""
         context = runtime_context or self.build_runtime_context(worktree_path)
@@ -75,6 +77,12 @@ class AgentProvider:
 
         if skip_permissions:
             parts.append(self.dangerous_flag)
+
+        if instruction:
+            if self.instruction_flag:
+                parts.extend([self.instruction_flag, instruction])
+            else:
+                parts.append(instruction)
 
         if "settings_path" in context.metadata:
             parts.extend(["--settings", context.metadata["settings_path"]])
@@ -183,6 +191,7 @@ PROVIDERS = {
         supports_completion_events=True,
         resume_pick_args=("--resume",),
         resume_last_args=("--resume",),
+        instruction_flag="-i",
     ),
 }
 

--- a/src/lazyagent/agent_providers.py
+++ b/src/lazyagent/agent_providers.py
@@ -94,10 +94,14 @@ class AgentProvider:
             return self.resume_last_args
         return ()
 
-    def build_runtime_context(self, worktree_path: str) -> ProviderRuntimeContext:
+    def build_runtime_context(
+        self,
+        worktree_path: str,
+        socket_path: str | None = None,
+    ) -> ProviderRuntimeContext:
         """Build provider-specific runtime metadata for the spawned session."""
         if self.name == "claude":
-            return _build_claude_runtime_context(self, worktree_path)
+            return _build_claude_runtime_context(self, worktree_path, socket_path)
         if self.name == "codex":
             return _build_codex_runtime_context(self, worktree_path)
         if self.name == "gemini":
@@ -267,6 +271,7 @@ def _build_codex_runtime_context(
 def _build_claude_runtime_context(
     provider: AgentProvider,
     worktree_path: str,
+    socket_path: str | None = None,
 ) -> ProviderRuntimeContext:
     temp_dir = Path(tempfile.mkdtemp(prefix="lazyagent-claude-hooks-"))
     hook_log_path = temp_dir / "hook-events.jsonl"
@@ -278,7 +283,7 @@ def _build_claude_runtime_context(
 
     hook_command = {"type": "command", "command": str(hook_script_path)}
 
-    hooks_settings = {
+    hooks_settings: dict = {
         "hooks": {
             "Notification": [
                 {
@@ -293,6 +298,19 @@ def _build_claude_runtime_context(
             "PostToolUse": [{"hooks": [hook_command]}],
         }
     }
+
+    if socket_path:
+        hooks_settings["mcpServers"] = {
+            "lazyagent": {
+                "command": "python3",
+                "args": ["-m", "lazyagent.mcp_server"],
+                "env": {
+                    "PYTHONUNBUFFERED": "1",
+                    "LAZYAGENT_SOCKET": socket_path,
+                },
+            }
+        }
+
     settings_path.write_text(json.dumps(hooks_settings), encoding="utf-8")
 
     return ProviderRuntimeContext(

--- a/src/lazyagent/agent_providers.py
+++ b/src/lazyagent/agent_providers.py
@@ -54,6 +54,7 @@ class AgentProvider:
     resume_last_args: tuple[str, ...] = ()
     resume_is_subcommand: bool = False
     instruction_flag: str | None = None
+    system_prompt_flag: str | None = None
 
     def build_command(
         self,
@@ -62,6 +63,7 @@ class AgentProvider:
         runtime_context: ProviderRuntimeContext | None = None,
         resume_mode: ResumeMode = ResumeMode.NEW,
         instruction: str | None = None,
+        system_prompt: str | None = None,
     ) -> str:
         """Build the full shell command used to launch this provider."""
         context = runtime_context or self.build_runtime_context(worktree_path)
@@ -77,6 +79,15 @@ class AgentProvider:
 
         if skip_permissions:
             parts.append(self.dangerous_flag)
+
+        if system_prompt:
+            if self.system_prompt_flag:
+                parts.extend([self.system_prompt_flag, system_prompt])
+            elif instruction:
+                # Providers without a dedicated flag: prepend to instruction
+                instruction = system_prompt + "\n\n" + instruction
+            else:
+                instruction = system_prompt
 
         if instruction:
             if self.instruction_flag:
@@ -174,6 +185,7 @@ PROVIDERS = {
         supports_completion_events=True,
         resume_pick_args=("--resume",),
         resume_last_args=("--continue",),
+        system_prompt_flag="--append-system-prompt",
     ),
     "codex": AgentProvider(
         name="codex",

--- a/src/lazyagent/agent_providers.py
+++ b/src/lazyagent/agent_providers.py
@@ -111,9 +111,9 @@ class AgentProvider:
         if self.name == "claude":
             return _build_claude_runtime_context(self, worktree_path, socket_path)
         if self.name == "codex":
-            return _build_codex_runtime_context(self, worktree_path)
+            return _build_codex_runtime_context(self, worktree_path, socket_path)
         if self.name == "gemini":
-            return _build_gemini_runtime_context(self, worktree_path)
+            return _build_gemini_runtime_context(self, worktree_path, socket_path)
         return ProviderRuntimeContext(
             provider_name=self.name,
             worktree_path=worktree_path,
@@ -232,18 +232,43 @@ def get_agent_provider(provider: str | None) -> AgentProvider:
 def _build_gemini_runtime_context(
     provider: AgentProvider,
     worktree_path: str,
+    socket_path: str | None = None,
 ) -> ProviderRuntimeContext:
     temp_dir = Path(tempfile.mkdtemp(prefix="lazyagent-gemini-telemetry-"))
     telemetry_log_path = temp_dir / "telemetry.jsonl"
+
+    env_overrides = {
+        "GEMINI_TELEMETRY_LOG": str(telemetry_log_path),
+    }
+
+    if socket_path:
+        # Gemini CLI reads settings.json from $GEMINI_CLI_HOME/.gemini/.
+        # Point it at a temp directory containing only our MCP entry.
+        gemini_home = temp_dir / "gemini_home"
+        (gemini_home / ".gemini").mkdir(parents=True, exist_ok=True)
+        settings = {
+            "mcpServers": {
+                "lazyagent": {
+                    "command": "python3",
+                    "args": ["-m", "lazyagent.mcp_server"],
+                    "env": {
+                        "PYTHONUNBUFFERED": "1",
+                        "LAZYAGENT_SOCKET": socket_path,
+                    },
+                }
+            }
+        }
+        (gemini_home / ".gemini" / "settings.json").write_text(
+            json.dumps(settings), encoding="utf-8"
+        )
+        env_overrides["GEMINI_CLI_HOME"] = str(gemini_home)
 
     return ProviderRuntimeContext(
         provider_name=provider.name,
         worktree_path=worktree_path,
         observation_mode=provider.observation_mode,
 
-        env_overrides={
-            "GEMINI_TELEMETRY_LOG": str(telemetry_log_path),
-        },
+        env_overrides=env_overrides,
         metadata={
             "temp_dir": str(temp_dir),
             "telemetry_log_path": str(telemetry_log_path),
@@ -254,6 +279,7 @@ def _build_gemini_runtime_context(
 def _build_codex_runtime_context(
     provider: AgentProvider,
     worktree_path: str,
+    socket_path: str | None = None,
 ) -> ProviderRuntimeContext:
     temp_dir = Path(tempfile.mkdtemp(prefix="lazyagent-codex-events-"))
     app_server_log_path = temp_dir / "app-server-events.jsonl"
@@ -262,14 +288,32 @@ def _build_codex_runtime_context(
     # or use a Codex-specific flag to pipe events to this file.
     # For now, we prepare the environment so Codex knows where to log.
 
+    env_overrides = {
+        "CODEX_APP_SERVER_LOG": str(app_server_log_path),
+    }
+
+    if socket_path:
+        # Codex reads MCP server config from $CODEX_HOME/config.toml.
+        # Point it at a temp directory containing only our MCP entry.
+        codex_home = temp_dir / "codex_home"
+        codex_home.mkdir(exist_ok=True)
+        config_toml = (
+            '[mcp_servers.lazyagent]\n'
+            f'command = "python3"\n'
+            f'args = ["-m", "lazyagent.mcp_server"]\n'
+            '\n[mcp_servers.lazyagent.env]\n'
+            'PYTHONUNBUFFERED = "1"\n'
+            f'LAZYAGENT_SOCKET = {json.dumps(socket_path)}\n'
+        )
+        (codex_home / "config.toml").write_text(config_toml, encoding="utf-8")
+        env_overrides["CODEX_HOME"] = str(codex_home)
+
     return ProviderRuntimeContext(
         provider_name=provider.name,
         worktree_path=worktree_path,
         observation_mode=provider.observation_mode,
 
-        env_overrides={
-            "CODEX_APP_SERVER_LOG": str(app_server_log_path),
-        },
+        env_overrides=env_overrides,
         metadata={
             "temp_dir": str(temp_dir),
             "app_server_log_path": str(app_server_log_path),

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -281,6 +281,7 @@ class LazyAgent(App):
                     skip_permissions=result.skip_permissions,
                     agent_provider=self._config.agent.provider,
                     resume_mode=result.resume_mode,
+                    instruction=result.instruction,
                 )
 
         self.push_screen(SpawnModal(worktree.display_label, agent_provider=self._config.agent.provider), on_spawn_dismiss)

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -11,6 +11,7 @@ from textual.widgets import Footer, Header
 from textual import work
 
 from lazyagent.config import Config, format_command, load_config
+from lazyagent.ipc import IpcServer, start_ipc_server
 from lazyagent.messages import AgentExited, AgentStatusChanged
 from lazyagent.models import AgentState, AgentStatus, GitStatus, WorktreeInfo
 from lazyagent.widgets.center_panel import CenterPanel
@@ -74,6 +75,8 @@ class LazyAgent(App):
         self._config: Config = Config()
         self._repo_root: str = ""
         self._gh_available: bool | None = None
+        self._ipc_server: IpcServer | None = None
+        self._ipc_socket_path: str | None = None
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -83,13 +86,21 @@ class LazyAgent(App):
         yield CenterPanel()
         yield Footer()
 
-    def on_mount(self) -> None:
+    async def on_mount(self) -> None:
         self._load_worktrees()
         self._load_config()
+        await self._start_ipc_server()
         self.set_interval(60, self._check_hangs)
         self.set_interval(30, self._refresh_git_statuses)
         self.set_interval(30, self._refresh_selected_diff)
         self.set_interval(60, self._refresh_pr_status)
+
+    async def _start_ipc_server(self) -> None:
+        """Start the IPC server for MCP communication."""
+        try:
+            self._ipc_server, self._ipc_socket_path = await start_ipc_server(self)
+        except Exception as e:
+            self.notify(f"IPC server failed to start: {e}", severity="warning", timeout=5)
 
     def _load_config(self) -> None:
         if self._repo_root:
@@ -342,6 +353,12 @@ class LazyAgent(App):
                 panel.query_one("#terminal-widget").focus()
             except Exception:
                 pass
+
+    async def action_quit(self) -> None:
+        if self._ipc_server is not None:
+            await self._ipc_server.stop()
+            self._ipc_server = None
+        self.exit()
 
     def action_refresh(self) -> None:
         self._load_worktrees()

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -74,7 +74,6 @@ class LazyAgent(App):
         self._git_statuses: dict[str, GitStatus] = {}
         self._selected_worktree: WorktreeInfo | None = None
         self._orchestrator_selected: bool = False
-        self._orchestrator_state: AgentState = AgentState()
         self._config: Config = Config()
         self._repo_root: str = ""
         self._gh_available: bool | None = None
@@ -149,10 +148,18 @@ class LazyAgent(App):
             return wt_list.highlighted_child.worktree
         return None
 
-    def _get_agent_state(self, worktree_path: str) -> AgentState:
-        if worktree_path not in self._agent_states:
-            self._agent_states[worktree_path] = AgentState()
-        return self._agent_states[worktree_path]
+    def _get_agent_state(self, key: str) -> AgentState:
+        """Get or create AgentState for a worktree path or ORCHESTRATOR_KEY."""
+        if key not in self._agent_states:
+            self._agent_states[key] = AgentState()
+        return self._agent_states[key]
+
+    def _get_any_panel(self, key: str):
+        """Get the panel for a worktree path or ORCHESTRATOR_KEY."""
+        center = self.query_one(CenterPanel)
+        if key == ORCHESTRATOR_KEY:
+            return center.get_orchestrator_panel()
+        return center.get_panel(key)
 
     def _refresh_git_statuses(self) -> None:
         """Fetch git statuses for all worktrees and push to UI."""
@@ -221,7 +228,7 @@ class LazyAgent(App):
         if event.item is not None and isinstance(event.item, OrchestratorListItem):
             self._orchestrator_selected = True
             self._selected_worktree = None
-            center.switch_to_orchestrator()
+            center.switch_to_orchestrator(self._repo_root)
         elif event.item is not None and isinstance(event.item, WorktreeListItem):
             self._orchestrator_selected = False
             self._selected_worktree = event.item.worktree
@@ -236,50 +243,17 @@ class LazyAgent(App):
     # --- Agent message handlers ---
 
     def on_agent_status_changed(self, event: AgentStatusChanged) -> None:
-        if event.worktree_path == ORCHESTRATOR_KEY:
-            self._orchestrator_state.status = event.status
-            self._orchestrator_state.confidence = event.confidence
-            self._orchestrator_state.detail = event.detail
-            if event.status == AgentStatus.RUNNING:
-                center = self.query_one(CenterPanel)
-                panel = center.get_orchestrator_panel()
-                if panel and panel.agent_terminal:
-                    self._orchestrator_state.last_output_time = panel.agent_terminal.last_output_time
-            self.query_one(WorktreeList).update_orchestrator_state(self._orchestrator_state)
-            return
-
         state = self._get_agent_state(event.worktree_path)
         state.status = event.status
         state.confidence = event.confidence
         state.detail = event.detail
         if event.status == AgentStatus.RUNNING:
-            # Update last_output_time from the terminal
-            center = self.query_one(CenterPanel)
-            panel = center.get_panel(event.worktree_path)
+            panel = self._get_any_panel(event.worktree_path)
             if panel and panel.agent_terminal:
                 state.last_output_time = panel.agent_terminal.last_output_time
         self.query_one(WorktreeList).update_agent_state(event.worktree_path, state)
 
     async def on_agent_exited(self, event: AgentExited) -> None:
-        if event.worktree_path == ORCHESTRATOR_KEY:
-            self._orchestrator_state.status = AgentStatus.NO_AGENT
-            self._orchestrator_state.confidence = LifecycleConfidence.LOW
-            self._orchestrator_state.detail = ""
-            self._orchestrator_state.last_output_time = None
-            self.query_one(WorktreeList).update_orchestrator_state(self._orchestrator_state)
-
-            center = self.query_one(CenterPanel)
-            panel = center.get_orchestrator_panel()
-            if panel is not None:
-                await panel.cleanup_agent()
-
-            self.notify(
-                "Orchestrator exited — press s to spawn again",
-                severity="warning",
-                timeout=5,
-            )
-            return
-
         state = self._get_agent_state(event.worktree_path)
         state.status = AgentStatus.NO_AGENT
         state.confidence = LifecycleConfidence.LOW
@@ -287,13 +261,13 @@ class LazyAgent(App):
         state.last_output_time = None
         self.query_one(WorktreeList).update_agent_state(event.worktree_path, state)
 
-        center = self.query_one(CenterPanel)
-        panel = center.get_panel(event.worktree_path)
+        panel = self._get_any_panel(event.worktree_path)
         if panel is not None:
             await panel.cleanup_agent()
 
+        label = "Orchestrator" if event.worktree_path == ORCHESTRATOR_KEY else "Agent"
         self.notify(
-            "Agent exited — press s to spawn again",
+            f"{label} exited — press s to spawn again",
             severity="warning",
             timeout=5,
         )
@@ -302,17 +276,9 @@ class LazyAgent(App):
 
     def _check_hangs(self) -> None:
         """Periodic timer callback: check all active agents for hangs."""
-        center = self.query_one(CenterPanel)
-
-        # Check orchestrator
-        if self._orchestrator_state.status == AgentStatus.RUNNING:
-            orch_panel = center.get_orchestrator_panel()
-            if orch_panel and orch_panel.agent_terminal:
-                orch_panel.agent_terminal.check_hang()
-
-        for worktree_path, state in self._agent_states.items():
+        for key, state in self._agent_states.items():
             if state.status == AgentStatus.RUNNING:
-                panel = center.get_panel(worktree_path)
+                panel = self._get_any_panel(key)
                 if panel and panel.agent_terminal:
                     panel.agent_terminal.check_hang()
 
@@ -351,18 +317,16 @@ class LazyAgent(App):
 
     def _spawn_orchestrator_agent(self) -> None:
         """Spawn agent in the orchestrator panel."""
-        center = self.query_one(CenterPanel)
-        orch_panel = center.get_orchestrator_panel()
-        if orch_panel and orch_panel.has_agent:
+        panel = self._get_any_panel(ORCHESTRATOR_KEY)
+        if panel and panel.has_agent:
             self.notify("Orchestrator agent already running", severity="warning")
             return
 
         async def on_spawn_dismiss(result: SpawnResult | None) -> None:
             if result is not None:
                 center = self.query_one(CenterPanel)
-                panel = center.switch_to_orchestrator()
+                panel = center.switch_to_orchestrator(self._repo_root)
                 await panel.spawn_agent(
-                    worktree_path=self._repo_root,
                     skip_permissions=result.skip_permissions,
                     agent_provider=self._config.agent.provider,
                     resume_mode=result.resume_mode,
@@ -398,15 +362,15 @@ class LazyAgent(App):
 
     async def _stop_orchestrator_agent(self) -> None:
         """Stop the orchestrator agent."""
-        center = self.query_one(CenterPanel)
-        panel = center.get_orchestrator_panel()
+        panel = self._get_any_panel(ORCHESTRATOR_KEY)
         if panel is None or not panel.has_agent:
             self.notify("No running orchestrator agent", severity="warning")
             return
 
-        self._orchestrator_state.status = AgentStatus.NO_AGENT
-        self._orchestrator_state.last_output_time = None
-        self.query_one(WorktreeList).update_orchestrator_state(self._orchestrator_state)
+        state = self._get_agent_state(ORCHESTRATOR_KEY)
+        state.status = AgentStatus.NO_AGENT
+        state.last_output_time = None
+        self.query_one(WorktreeList).update_agent_state(ORCHESTRATOR_KEY, state)
         await panel.cleanup_agent()
         self.notify("Orchestrator agent stopped")
 

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -13,7 +13,7 @@ from textual import work
 from lazyagent.config import Config, format_command, load_config
 from lazyagent.ipc import IpcServer, start_ipc_server
 from lazyagent.messages import AgentExited, AgentStatusChanged
-from lazyagent.models import AgentState, AgentStatus, GitStatus, WorktreeInfo
+from lazyagent.models import AgentState, AgentStatus, GitStatus, LifecycleConfidence, WorktreeInfo
 from lazyagent.widgets.center_panel import CenterPanel
 from lazyagent.widgets.help_modal import HelpModal
 from lazyagent.widgets.create_worktree_modal import CreateWorktreeModal, CreateWorktreeResult
@@ -292,6 +292,7 @@ class LazyAgent(App):
                     skip_permissions=result.skip_permissions,
                     agent_provider=self._config.agent.provider,
                     resume_mode=result.resume_mode,
+                    socket_path=self._ipc_socket_path,
                 )
 
         self.push_screen(SpawnModal(worktree.display_label, agent_provider=self._config.agent.provider), on_spawn_dismiss)

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -20,7 +20,8 @@ from lazyagent.widgets.create_worktree_modal import CreateWorktreeModal, CreateW
 from lazyagent.widgets.remove_worktree_modal import RemoveWorktreeModal, RemoveWorktreeResult
 from lazyagent.widgets.pr_status_bar import PrStatusBar
 from lazyagent.widgets.prompt_modal import SpawnModal, SpawnResult
-from lazyagent.widgets.worktree_list import WorktreeList, WorktreeListItem
+from lazyagent.widgets.orchestrator_panel import ORCHESTRATOR_KEY
+from lazyagent.widgets.worktree_list import OrchestratorListItem, WorktreeList, WorktreeListItem
 from lazyagent.worktree_manager import WorktreeManager, WorktreeManagerError, find_repo_root
 
 
@@ -72,6 +73,8 @@ class LazyAgent(App):
         self._agent_states: dict[str, AgentState] = {}
         self._git_statuses: dict[str, GitStatus] = {}
         self._selected_worktree: WorktreeInfo | None = None
+        self._orchestrator_selected: bool = False
+        self._orchestrator_state: AgentState = AgentState()
         self._config: Config = Config()
         self._repo_root: str = ""
         self._gh_available: bool | None = None
@@ -215,18 +218,36 @@ class LazyAgent(App):
 
     def on_list_view_highlighted(self, event: WorktreeList.Highlighted) -> None:
         center = self.query_one(CenterPanel)
-        if event.item is not None and isinstance(event.item, WorktreeListItem):
+        if event.item is not None and isinstance(event.item, OrchestratorListItem):
+            self._orchestrator_selected = True
+            self._selected_worktree = None
+            center.switch_to_orchestrator()
+        elif event.item is not None and isinstance(event.item, WorktreeListItem):
+            self._orchestrator_selected = False
             self._selected_worktree = event.item.worktree
             center.switch_to(event.item.worktree.path)
             self._push_git_status_to_selected_panel()
             self._refresh_selected_diff()
             self._refresh_pr_status()
         else:
+            self._orchestrator_selected = False
             self._selected_worktree = None
 
     # --- Agent message handlers ---
 
     def on_agent_status_changed(self, event: AgentStatusChanged) -> None:
+        if event.worktree_path == ORCHESTRATOR_KEY:
+            self._orchestrator_state.status = event.status
+            self._orchestrator_state.confidence = event.confidence
+            self._orchestrator_state.detail = event.detail
+            if event.status == AgentStatus.RUNNING:
+                center = self.query_one(CenterPanel)
+                panel = center.get_orchestrator_panel()
+                if panel and panel.agent_terminal:
+                    self._orchestrator_state.last_output_time = panel.agent_terminal.last_output_time
+            self.query_one(WorktreeList).update_orchestrator_state(self._orchestrator_state)
+            return
+
         state = self._get_agent_state(event.worktree_path)
         state.status = event.status
         state.confidence = event.confidence
@@ -240,6 +261,25 @@ class LazyAgent(App):
         self.query_one(WorktreeList).update_agent_state(event.worktree_path, state)
 
     async def on_agent_exited(self, event: AgentExited) -> None:
+        if event.worktree_path == ORCHESTRATOR_KEY:
+            self._orchestrator_state.status = AgentStatus.NO_AGENT
+            self._orchestrator_state.confidence = LifecycleConfidence.LOW
+            self._orchestrator_state.detail = ""
+            self._orchestrator_state.last_output_time = None
+            self.query_one(WorktreeList).update_orchestrator_state(self._orchestrator_state)
+
+            center = self.query_one(CenterPanel)
+            panel = center.get_orchestrator_panel()
+            if panel is not None:
+                await panel.cleanup_agent()
+
+            self.notify(
+                "Orchestrator exited — press s to spawn again",
+                severity="warning",
+                timeout=5,
+            )
+            return
+
         state = self._get_agent_state(event.worktree_path)
         state.status = AgentStatus.NO_AGENT
         state.confidence = LifecycleConfidence.LOW
@@ -263,6 +303,13 @@ class LazyAgent(App):
     def _check_hangs(self) -> None:
         """Periodic timer callback: check all active agents for hangs."""
         center = self.query_one(CenterPanel)
+
+        # Check orchestrator
+        if self._orchestrator_state.status == AgentStatus.RUNNING:
+            orch_panel = center.get_orchestrator_panel()
+            if orch_panel and orch_panel.agent_terminal:
+                orch_panel.agent_terminal.check_hang()
+
         for worktree_path, state in self._agent_states.items():
             if state.status == AgentStatus.RUNNING:
                 panel = center.get_panel(worktree_path)
@@ -272,6 +319,10 @@ class LazyAgent(App):
     # --- Actions ---
 
     def action_spawn_agent(self) -> None:
+        if self._orchestrator_selected:
+            self._spawn_orchestrator_agent()
+            return
+
         worktree = self._get_selected_worktree()
         if worktree is None:
             self.notify("No worktree selected", severity="warning")
@@ -298,7 +349,34 @@ class LazyAgent(App):
 
         self.push_screen(SpawnModal(worktree.display_label, agent_provider=self._config.agent.provider), on_spawn_dismiss)
 
+    def _spawn_orchestrator_agent(self) -> None:
+        """Spawn agent in the orchestrator panel."""
+        center = self.query_one(CenterPanel)
+        orch_panel = center.get_orchestrator_panel()
+        if orch_panel and orch_panel.has_agent:
+            self.notify("Orchestrator agent already running", severity="warning")
+            return
+
+        async def on_spawn_dismiss(result: SpawnResult | None) -> None:
+            if result is not None:
+                center = self.query_one(CenterPanel)
+                panel = center.switch_to_orchestrator()
+                await panel.spawn_agent(
+                    worktree_path=self._repo_root,
+                    skip_permissions=result.skip_permissions,
+                    agent_provider=self._config.agent.provider,
+                    resume_mode=result.resume_mode,
+                    socket_path=self._ipc_socket_path,
+                    instruction=result.instruction,
+                )
+
+        self.push_screen(SpawnModal("Orchestrator", agent_provider=self._config.agent.provider), on_spawn_dismiss)
+
     async def action_stop_agent(self) -> None:
+        if self._orchestrator_selected:
+            await self._stop_orchestrator_agent()
+            return
+
         worktree = self._get_selected_worktree()
         if worktree is None:
             self.notify("No worktree selected", severity="warning")
@@ -318,10 +396,32 @@ class LazyAgent(App):
         await panel.cleanup_agent()
         self.notify("Agent stopped")
 
+    async def _stop_orchestrator_agent(self) -> None:
+        """Stop the orchestrator agent."""
+        center = self.query_one(CenterPanel)
+        panel = center.get_orchestrator_panel()
+        if panel is None or not panel.has_agent:
+            self.notify("No running orchestrator agent", severity="warning")
+            return
+
+        self._orchestrator_state.status = AgentStatus.NO_AGENT
+        self._orchestrator_state.last_output_time = None
+        self.query_one(WorktreeList).update_orchestrator_state(self._orchestrator_state)
+        await panel.cleanup_agent()
+        self.notify("Orchestrator agent stopped")
+
     def action_focus_sidebar(self) -> None:
         self.query_one(WorktreeList).focus()
 
     def action_focus_agent(self) -> None:
+        if self._orchestrator_selected:
+            panel = self.query_one(CenterPanel).get_orchestrator_panel()
+            if panel and panel.agent_terminal:
+                panel.agent_terminal.focus()
+            else:
+                self.action_spawn_agent()
+            return
+
         wt = self._get_selected_worktree()
         if not wt:
             return

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -11,6 +11,7 @@ from textual.widgets import Footer, Header
 from textual import work
 
 from lazyagent.config import Config, format_command, load_config
+from lazyagent.orchestrator_prompt import compose_orchestrator_prompt
 from lazyagent.ipc import IpcServer, start_ipc_server
 from lazyagent.messages import AgentExited, AgentStatusChanged
 from lazyagent.models import AgentState, AgentStatus, GitStatus, LifecycleConfidence, WorktreeInfo
@@ -322,6 +323,8 @@ class LazyAgent(App):
             self.notify("Orchestrator agent already running", severity="warning")
             return
 
+        orch_prompt = compose_orchestrator_prompt(self._config, self._repo_root)
+
         async def on_spawn_dismiss(result: SpawnResult | None) -> None:
             if result is not None:
                 center = self.query_one(CenterPanel)
@@ -332,6 +335,7 @@ class LazyAgent(App):
                     resume_mode=result.resume_mode,
                     socket_path=self._ipc_socket_path,
                     instruction=result.instruction,
+                    system_prompt=orch_prompt,
                 )
 
         self.push_screen(SpawnModal("Orchestrator", agent_provider=self._config.agent.provider), on_spawn_dismiss)

--- a/src/lazyagent/config.py
+++ b/src/lazyagent/config.py
@@ -37,11 +37,20 @@ class AgentConfig:
 
 
 @dataclass
+class OrchestratorConfig:
+    """Configuration for the orchestrator agent."""
+
+    prompt_file: str | None = None
+    agent_instruction_template: str | None = None
+
+
+@dataclass
 class Config:
     """Application configuration loaded from .lazyagent.toml."""
 
     worktree: WorktreeConfig = field(default_factory=WorktreeConfig)
     agent: AgentConfig = field(default_factory=AgentConfig)
+    orchestrator: OrchestratorConfig = field(default_factory=OrchestratorConfig)
     default_branch: str = DEFAULT_BRANCH
 
     @property
@@ -75,10 +84,16 @@ def load_config(repo_root: str | Path) -> Config:
     )
     agent_data = data.get("agent", {})
     provider = normalize_provider_name(agent_data.get("provider"))
+    orch_data = data.get("orchestrator", {})
+    orchestrator_config = OrchestratorConfig(
+        prompt_file=orch_data.get("prompt_file"),
+        agent_instruction_template=orch_data.get("agent_instruction_template"),
+    )
     default_branch = data.get("default_branch", DEFAULT_BRANCH)
     return Config(
         worktree=worktree_config,
         agent=AgentConfig(provider=provider),
+        orchestrator=orchestrator_config,
         default_branch=default_branch,
     )
 

--- a/src/lazyagent/ipc.py
+++ b/src/lazyagent/ipc.py
@@ -47,6 +47,15 @@ class IpcServer:
         self._app = app
         self._socket_path = socket_path
         self._server: asyncio.AbstractServer | None = None
+        self._handlers = {
+            "list_worktrees": self.handle_list_worktrees,
+            "create_worktree": self.handle_create_worktree,
+            "remove_worktree": self.handle_remove_worktree,
+            "spawn_agent": self.handle_spawn_agent,
+            "stop_agent": self.handle_stop_agent,
+            "get_agent_status": self.handle_get_agent_status,
+            "read_agent_output": self.handle_read_agent_output,
+        }
 
     @property
     def socket_path(self) -> str:
@@ -110,15 +119,7 @@ class IpcServer:
     async def _dispatch(
         self, request_id: str, method: str, params: dict
     ) -> dict:
-        handler = {
-            "list_worktrees": self.handle_list_worktrees,
-            "create_worktree": self.handle_create_worktree,
-            "remove_worktree": self.handle_remove_worktree,
-            "spawn_agent": self.handle_spawn_agent,
-            "stop_agent": self.handle_stop_agent,
-            "get_agent_status": self.handle_get_agent_status,
-            "read_agent_output": self.handle_read_agent_output,
-        }.get(method)
+        handler = self._handlers.get(method)
 
         if handler is None:
             return _err(request_id, "UNKNOWN_METHOD", f"Unknown method: {method}")
@@ -229,7 +230,7 @@ class IpcServer:
         if state and state.status in (AgentStatus.RUNNING, AgentStatus.WAITING):
             raise ValueError("Agent is already running in this worktree")
 
-        future: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         initial_prompt = params.get("initial_prompt")
 
         async def _do_spawn() -> None:
@@ -241,6 +242,7 @@ class IpcServer:
                 await panel.spawn_agent(
                     skip_permissions=True,
                     agent_provider=self._app._config.agent.provider,
+                    socket_path=self._socket_path,
                 )
                 # If there's an initial prompt, send it to the agent terminal
                 if initial_prompt and panel.agent_terminal:
@@ -273,13 +275,18 @@ class IpcServer:
         if panel is None or not panel.has_agent:
             raise ValueError("No running agent in this worktree")
 
-        future: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
 
         async def _do_stop() -> None:
             try:
+                from lazyagent.widgets.worktree_list import WorktreeList
+
                 state = self._app._get_agent_state(worktree_path)
                 state.status = AgentStatus.NO_AGENT
                 state.last_output_time = None
+                self._app.query_one(WorktreeList).update_agent_state(
+                    worktree_path, state
+                )
                 await panel.cleanup_agent()
                 future.set_result(None)
             except Exception as e:
@@ -331,38 +338,40 @@ class IpcServer:
 
         terminal = panel.agent_terminal
         screen = terminal._screen
+        total_lines = len(screen.scrollback) + screen.lines
 
-        # Collect lines from scrollback + live screen buffer
-        lines: list[str] = []
+        def _row_text(row_data: dict) -> str:
+            return "".join(
+                row_data.get(x, screen.default_char).data
+                for x in range(screen.columns)
+            ).rstrip()
 
-        # Scrollback lines
-        for row_data in screen.scrollback:
-            line_chars = []
-            if row_data:
-                max_col = max(row_data.keys())
-                for col in range(max_col + 1):
-                    char = row_data.get(col)
-                    line_chars.append(char.data if char else " ")
-            lines.append("".join(line_chars).rstrip())
+        # Collect only the last num_lines by iterating from the end:
+        # first the live screen buffer (bottom), then scrollback (top).
+        collected: list[str] = []
+        remaining = min(num_lines, total_lines)
 
-        # Live screen lines
-        for row in range(screen.lines):
-            row_data = screen.buffer[row]
-            line_chars = []
-            if row_data:
-                max_col = max(row_data.keys()) if row_data else -1
-                for col in range(max_col + 1):
-                    char = row_data.get(col)
-                    line_chars.append(char.data if char else " ")
-            lines.append("".join(line_chars).rstrip())
+        # Live screen lines (bottom-up)
+        for row in range(screen.lines - 1, -1, -1):
+            if remaining <= 0:
+                break
+            collected.append(_row_text(screen.buffer[row]))
+            remaining -= 1
 
-        # Take the last N lines
-        output_lines = lines[-num_lines:]
+        # Scrollback lines (bottom-up)
+        if remaining > 0:
+            for row_data in reversed(screen.scrollback):
+                if remaining <= 0:
+                    break
+                collected.append(_row_text(row_data))
+                remaining -= 1
+
+        collected.reverse()
 
         return _ok(request_id, {
             "worktree_path": worktree_path,
-            "lines": output_lines,
-            "total_lines": len(lines),
+            "lines": collected,
+            "total_lines": total_lines,
         })
 
     # ------------------------------------------------------------------

--- a/src/lazyagent/ipc.py
+++ b/src/lazyagent/ipc.py
@@ -216,7 +216,7 @@ class IpcServer:
     async def handle_spawn_agent(
         self, request_id: str, params: dict
     ) -> dict:
-        """Spawn an agent in a worktree. Params: worktree_path, initial_prompt (optional)."""
+        """Spawn an agent in a worktree. Params: worktree_path, instruction (optional)."""
         worktree_path = params.get("worktree_path", "")
         if not worktree_path:
             raise ValueError("worktree_path is required")
@@ -231,7 +231,7 @@ class IpcServer:
             raise ValueError("Agent is already running in this worktree")
 
         future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
-        initial_prompt = params.get("initial_prompt")
+        instruction = params.get("instruction") or params.get("initial_prompt")
 
         async def _do_spawn() -> None:
             try:
@@ -243,14 +243,8 @@ class IpcServer:
                     skip_permissions=True,
                     agent_provider=self._app._config.agent.provider,
                     socket_path=self._socket_path,
+                    instruction=instruction,
                 )
-                # If there's an initial prompt, send it to the agent terminal
-                if initial_prompt and panel.agent_terminal:
-                    # Give the agent a moment to initialize
-                    await asyncio.sleep(0.5)
-                    panel.agent_terminal.send_queue.put_nowait(
-                        ["stdin", initial_prompt + "\n"]
-                    )
                 future.set_result(None)
             except Exception as e:
                 future.set_exception(e)

--- a/src/lazyagent/ipc.py
+++ b/src/lazyagent/ipc.py
@@ -1,0 +1,398 @@
+"""IPC server — Unix domain socket server running inside the Textual app.
+
+Receives JSON requests from the MCP server process, dispatches to handlers
+that operate on the ``LazyAgent`` app instance.
+
+Protocol: newline-delimited JSON.
+
+    Request:  {"id": "uuid", "method": "list_worktrees", "params": {}}
+    Success:  {"id": "uuid", "result": [...]}
+    Error:    {"id": "uuid", "error": {"code": "...", "message": "..."}}
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from lazyagent.models import AgentStatus
+from lazyagent.worktree_manager import WorktreeManager, WorktreeManagerError
+
+if TYPE_CHECKING:
+    from lazyagent.app import LazyAgent
+
+log = logging.getLogger(__name__)
+
+# How long we wait for Textual-thread operations (spawn/stop agent)
+_TEXTUAL_OP_TIMEOUT = 30.0
+
+
+def _ok(request_id: str, result: Any) -> dict:
+    return {"id": request_id, "result": result}
+
+
+def _err(request_id: str, code: str, message: str) -> dict:
+    return {"id": request_id, "error": {"code": code, "message": message}}
+
+
+class IpcServer:
+    """Asyncio Unix domain socket server bound to the Textual app."""
+
+    def __init__(self, app: LazyAgent, socket_path: str) -> None:
+        self._app = app
+        self._socket_path = socket_path
+        self._server: asyncio.AbstractServer | None = None
+
+    @property
+    def socket_path(self) -> str:
+        return self._socket_path
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_unix_server(
+            self._handle_client,
+            path=self._socket_path,
+        )
+        log.info("IPC server listening on %s", self._socket_path)
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+        try:
+            os.unlink(self._socket_path)
+        except FileNotFoundError:
+            pass
+        # Remove the parent directory if empty
+        parent = os.path.dirname(self._socket_path)
+        try:
+            os.rmdir(parent)
+        except OSError:
+            pass
+
+    async def _handle_client(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """Handle a single client connection (one request per line)."""
+        try:
+            while True:
+                line = await reader.readline()
+                if not line:
+                    break
+                try:
+                    request = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                request_id = request.get("id", "")
+                method = request.get("method", "")
+                params = request.get("params", {})
+
+                response = await self._dispatch(request_id, method, params)
+                writer.write(json.dumps(response).encode() + b"\n")
+                await writer.drain()
+        except (ConnectionResetError, BrokenPipeError):
+            pass
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionResetError, BrokenPipeError):
+                pass
+
+    async def _dispatch(
+        self, request_id: str, method: str, params: dict
+    ) -> dict:
+        handler = {
+            "list_worktrees": self.handle_list_worktrees,
+            "create_worktree": self.handle_create_worktree,
+            "remove_worktree": self.handle_remove_worktree,
+            "spawn_agent": self.handle_spawn_agent,
+            "stop_agent": self.handle_stop_agent,
+            "get_agent_status": self.handle_get_agent_status,
+            "read_agent_output": self.handle_read_agent_output,
+        }.get(method)
+
+        if handler is None:
+            return _err(request_id, "UNKNOWN_METHOD", f"Unknown method: {method}")
+
+        try:
+            result = await handler(request_id, params)
+            return result
+        except WorktreeManagerError as e:
+            return _err(request_id, "WORKTREE_ERROR", str(e))
+        except ValueError as e:
+            return _err(request_id, "VALIDATION_ERROR", str(e))
+        except TimeoutError:
+            return _err(request_id, "TIMEOUT", "Operation timed out")
+        except Exception as e:
+            log.exception("IPC handler error for method=%s", method)
+            return _err(request_id, "INTERNAL_ERROR", str(e))
+
+    # ------------------------------------------------------------------
+    # Handlers
+    # ------------------------------------------------------------------
+
+    async def handle_list_worktrees(
+        self, request_id: str, params: dict
+    ) -> dict:
+        """List all worktrees with agent status and git status."""
+        result = []
+        for wt in self._app.worktrees:
+            state = self._app._agent_states.get(wt.path)
+            git_st = self._app._git_statuses.get(wt.path)
+            entry: dict[str, Any] = {
+                "path": wt.path,
+                "branch": wt.branch,
+                "head": wt.head,
+                "is_main": wt.is_main,
+                "is_bare": wt.is_bare,
+                "agent_status": state.status.value if state else AgentStatus.NO_AGENT.value,
+            }
+            if git_st:
+                entry["git_status"] = {
+                    "dirty_count": git_st.dirty_count,
+                    "ahead": git_st.ahead,
+                    "behind": git_st.behind,
+                }
+            result.append(entry)
+        return _ok(request_id, result)
+
+    async def handle_create_worktree(
+        self, request_id: str, params: dict
+    ) -> dict:
+        """Create a new worktree. Params: branch, base_branch (optional)."""
+        branch = params.get("branch", "").strip()
+        if not branch:
+            raise ValueError("branch is required and must not be empty")
+        base_branch = params.get("base_branch", "main")
+
+        manager = WorktreeManager(self._app._repo_root)
+        new_path = await asyncio.to_thread(manager.create, branch, base_branch)
+
+        # Refresh the worktree list on the Textual thread
+        self._app.call_later(self._app._load_worktrees)
+
+        return _ok(request_id, {"path": new_path, "branch": branch})
+
+    async def handle_remove_worktree(
+        self, request_id: str, params: dict
+    ) -> dict:
+        """Remove a worktree. Params: worktree_path, force (optional)."""
+        worktree_path = params.get("worktree_path", "")
+        force = params.get("force", False)
+
+        if not worktree_path:
+            raise ValueError("worktree_path is required")
+
+        # Reject main worktree
+        wt_info = self._find_worktree(worktree_path)
+        if wt_info is None:
+            raise ValueError(f"Unknown worktree: {worktree_path}")
+        if wt_info.is_main:
+            raise ValueError("Cannot remove the main worktree")
+
+        # Reject if agent is running
+        state = self._app._agent_states.get(worktree_path)
+        if state and state.status in (AgentStatus.RUNNING, AgentStatus.WAITING):
+            raise ValueError("Agent is running in this worktree — stop it first")
+
+        manager = WorktreeManager(self._app._repo_root)
+        await asyncio.to_thread(manager.remove, worktree_path, force)
+
+        self._app._agent_states.pop(worktree_path, None)
+        self._app.call_later(self._app._load_worktrees)
+
+        return _ok(request_id, {"removed": worktree_path})
+
+    async def handle_spawn_agent(
+        self, request_id: str, params: dict
+    ) -> dict:
+        """Spawn an agent in a worktree. Params: worktree_path, initial_prompt (optional)."""
+        worktree_path = params.get("worktree_path", "")
+        if not worktree_path:
+            raise ValueError("worktree_path is required")
+
+        wt_info = self._find_worktree(worktree_path)
+        if wt_info is None:
+            raise ValueError(f"Unknown worktree: {worktree_path}")
+
+        # Reject if agent already running
+        state = self._app._agent_states.get(worktree_path)
+        if state and state.status in (AgentStatus.RUNNING, AgentStatus.WAITING):
+            raise ValueError("Agent is already running in this worktree")
+
+        future: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        initial_prompt = params.get("initial_prompt")
+
+        async def _do_spawn() -> None:
+            try:
+                from lazyagent.widgets.center_panel import CenterPanel
+
+                center = self._app.query_one(CenterPanel)
+                panel = center.ensure_panel(worktree_path)
+                await panel.spawn_agent(
+                    skip_permissions=True,
+                    agent_provider=self._app._config.agent.provider,
+                )
+                # If there's an initial prompt, send it to the agent terminal
+                if initial_prompt and panel.agent_terminal:
+                    # Give the agent a moment to initialize
+                    await asyncio.sleep(0.5)
+                    panel.agent_terminal.send_queue.put_nowait(
+                        ["stdin", initial_prompt + "\n"]
+                    )
+                future.set_result(None)
+            except Exception as e:
+                future.set_exception(e)
+
+        self._app.call_later(_do_spawn)
+
+        await asyncio.wait_for(future, timeout=_TEXTUAL_OP_TIMEOUT)
+        return _ok(request_id, {"worktree_path": worktree_path, "status": "spawned"})
+
+    async def handle_stop_agent(
+        self, request_id: str, params: dict
+    ) -> dict:
+        """Stop the agent in a worktree. Params: worktree_path."""
+        worktree_path = params.get("worktree_path", "")
+        if not worktree_path:
+            raise ValueError("worktree_path is required")
+
+        from lazyagent.widgets.center_panel import CenterPanel
+
+        center = self._app.query_one(CenterPanel)
+        panel = center.get_panel(worktree_path)
+        if panel is None or not panel.has_agent:
+            raise ValueError("No running agent in this worktree")
+
+        future: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+
+        async def _do_stop() -> None:
+            try:
+                state = self._app._get_agent_state(worktree_path)
+                state.status = AgentStatus.NO_AGENT
+                state.last_output_time = None
+                await panel.cleanup_agent()
+                future.set_result(None)
+            except Exception as e:
+                future.set_exception(e)
+
+        self._app.call_later(_do_stop)
+
+        await asyncio.wait_for(future, timeout=_TEXTUAL_OP_TIMEOUT)
+        return _ok(request_id, {"worktree_path": worktree_path, "status": "stopped"})
+
+    async def handle_get_agent_status(
+        self, request_id: str, params: dict
+    ) -> dict:
+        """Get agent status for a worktree. Params: worktree_path."""
+        worktree_path = params.get("worktree_path", "")
+        if not worktree_path:
+            raise ValueError("worktree_path is required")
+
+        state = self._app._agent_states.get(worktree_path)
+        if state is None:
+            return _ok(request_id, {
+                "worktree_path": worktree_path,
+                "status": AgentStatus.NO_AGENT.value,
+                "detail": "",
+            })
+
+        return _ok(request_id, {
+            "worktree_path": worktree_path,
+            "status": state.status.value,
+            "confidence": state.confidence.value,
+            "detail": state.detail,
+        })
+
+    async def handle_read_agent_output(
+        self, request_id: str, params: dict
+    ) -> dict:
+        """Read recent terminal output from an agent. Params: worktree_path, lines (optional)."""
+        worktree_path = params.get("worktree_path", "")
+        num_lines = params.get("lines", 50)
+        if not worktree_path:
+            raise ValueError("worktree_path is required")
+
+        from lazyagent.widgets.center_panel import CenterPanel
+
+        center = self._app.query_one(CenterPanel)
+        panel = center.get_panel(worktree_path)
+        if panel is None or panel.agent_terminal is None:
+            raise ValueError("No agent terminal in this worktree")
+
+        terminal = panel.agent_terminal
+        screen = terminal._screen
+
+        # Collect lines from scrollback + live screen buffer
+        lines: list[str] = []
+
+        # Scrollback lines
+        for row_data in screen.scrollback:
+            line_chars = []
+            if row_data:
+                max_col = max(row_data.keys())
+                for col in range(max_col + 1):
+                    char = row_data.get(col)
+                    line_chars.append(char.data if char else " ")
+            lines.append("".join(line_chars).rstrip())
+
+        # Live screen lines
+        for row in range(screen.lines):
+            row_data = screen.buffer[row]
+            line_chars = []
+            if row_data:
+                max_col = max(row_data.keys()) if row_data else -1
+                for col in range(max_col + 1):
+                    char = row_data.get(col)
+                    line_chars.append(char.data if char else " ")
+            lines.append("".join(line_chars).rstrip())
+
+        # Take the last N lines
+        output_lines = lines[-num_lines:]
+
+        return _ok(request_id, {
+            "worktree_path": worktree_path,
+            "lines": output_lines,
+            "total_lines": len(lines),
+        })
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _find_worktree(self, path: str):
+        """Find a WorktreeInfo by path."""
+        for wt in self._app.worktrees:
+            if wt.path == path:
+                return wt
+        return None
+
+
+async def start_ipc_server(app: LazyAgent) -> tuple[IpcServer, str]:
+    """Factory: create and start an IPC server for the given app.
+
+    Returns ``(server, socket_path)``.
+    Socket is created at ``/tmp/lazyagent-{pid}/ipc.sock``.
+    """
+    socket_dir = os.path.join(tempfile.gettempdir(), f"lazyagent-{os.getpid()}")
+    os.makedirs(socket_dir, exist_ok=True)
+    socket_path = os.path.join(socket_dir, "ipc.sock")
+
+    # Remove stale socket if present
+    try:
+        os.unlink(socket_path)
+    except FileNotFoundError:
+        pass
+
+    server = IpcServer(app, socket_path)
+    await server.start()
+    return server, socket_path

--- a/src/lazyagent/mcp_server.py
+++ b/src/lazyagent/mcp_server.py
@@ -58,14 +58,20 @@ class IpcClient:
                 pass
 
 
+_cached_client: IpcClient | None = None
+
+
 def _get_client() -> IpcClient:
-    socket_path = os.environ.get("LAZYAGENT_SOCKET")
-    if not socket_path:
-        raise RuntimeError(
-            "LAZYAGENT_SOCKET environment variable is not set. "
-            "This server must be started by lazyagent."
-        )
-    return IpcClient(socket_path)
+    global _cached_client
+    if _cached_client is None:
+        socket_path = os.environ.get("LAZYAGENT_SOCKET")
+        if not socket_path:
+            raise RuntimeError(
+                "LAZYAGENT_SOCKET environment variable is not set. "
+                "This server must be started by lazyagent."
+            )
+        _cached_client = IpcClient(socket_path)
+    return _cached_client
 
 
 # ------------------------------------------------------------------

--- a/src/lazyagent/mcp_server.py
+++ b/src/lazyagent/mcp_server.py
@@ -127,7 +127,7 @@ async def remove_worktree(worktree_path: str, force: bool = False) -> dict:
 
 @mcp.tool()
 async def spawn_agent(
-    worktree_path: str, initial_prompt: str | None = None
+    worktree_path: str, instruction: str | None = None
 ) -> dict:
     """Spawn a coding agent in a worktree.
 
@@ -136,14 +136,14 @@ async def spawn_agent(
 
     Args:
         worktree_path: Absolute path of the worktree.
-        initial_prompt: Optional initial prompt to send to the agent after it starts.
+        instruction: Optional initial instruction passed to the agent CLI.
 
     Returns:
         Object with worktree_path and status.
     """
     params: dict[str, Any] = {"worktree_path": worktree_path}
-    if initial_prompt is not None:
-        params["initial_prompt"] = initial_prompt
+    if instruction is not None:
+        params["instruction"] = instruction
     return await _get_client().call("spawn_agent", params)
 
 

--- a/src/lazyagent/mcp_server.py
+++ b/src/lazyagent/mcp_server.py
@@ -1,0 +1,196 @@
+"""MCP stdio server — spawned by Claude Code as a child process.
+
+Exposes lazyagent primitives (worktree management, agent lifecycle) as MCP
+tools. Communicates with the main lazyagent app via a Unix domain socket
+whose path is read from the ``LAZYAGENT_SOCKET`` environment variable.
+
+Run with: ``python3 -m lazyagent.mcp_server``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("lazyagent")
+
+
+class IpcClient:
+    """Thin client that talks to the lazyagent IPC server over a Unix socket.
+
+    Opens a fresh connection per call (stateless).
+    """
+
+    def __init__(self, socket_path: str) -> None:
+        self._socket_path = socket_path
+
+    async def call(self, method: str, params: dict | None = None) -> Any:
+        """Send a JSON request and return the result (or raise on error)."""
+        reader, writer = await asyncio.open_unix_connection(self._socket_path)
+        try:
+            request = {
+                "id": str(uuid.uuid4()),
+                "method": method,
+                "params": params or {},
+            }
+            writer.write(json.dumps(request).encode() + b"\n")
+            await writer.drain()
+
+            line = await reader.readline()
+            if not line:
+                raise ConnectionError("IPC server closed the connection")
+
+            response = json.loads(line)
+            if "error" in response:
+                err = response["error"]
+                raise RuntimeError(f"[{err.get('code', 'ERROR')}] {err.get('message', '')}")
+            return response.get("result")
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionResetError, BrokenPipeError):
+                pass
+
+
+def _get_client() -> IpcClient:
+    socket_path = os.environ.get("LAZYAGENT_SOCKET")
+    if not socket_path:
+        raise RuntimeError(
+            "LAZYAGENT_SOCKET environment variable is not set. "
+            "This server must be started by lazyagent."
+        )
+    return IpcClient(socket_path)
+
+
+# ------------------------------------------------------------------
+# MCP Tools
+# ------------------------------------------------------------------
+
+
+@mcp.tool()
+async def list_worktrees() -> list[dict]:
+    """List all git worktrees with their agent status and git status.
+
+    Returns a list of worktree objects with fields: path, branch, head,
+    is_main, is_bare, agent_status, and optionally git_status.
+    """
+    return await _get_client().call("list_worktrees")
+
+
+@mcp.tool()
+async def create_worktree(branch: str, base_branch: str = "main") -> dict:
+    """Create a new git worktree with a new branch.
+
+    Args:
+        branch: Name for the new branch.
+        base_branch: Branch to base the new worktree on. Defaults to "main".
+
+    Returns:
+        Object with path and branch of the new worktree.
+    """
+    return await _get_client().call(
+        "create_worktree",
+        {"branch": branch, "base_branch": base_branch},
+    )
+
+
+@mcp.tool()
+async def remove_worktree(worktree_path: str, force: bool = False) -> dict:
+    """Remove a git worktree.
+
+    Cannot remove the main worktree or a worktree with a running agent.
+
+    Args:
+        worktree_path: Absolute path of the worktree to remove.
+        force: If True, force removal even if there are uncommitted changes.
+
+    Returns:
+        Object confirming the removal.
+    """
+    return await _get_client().call(
+        "remove_worktree",
+        {"worktree_path": worktree_path, "force": force},
+    )
+
+
+@mcp.tool()
+async def spawn_agent(
+    worktree_path: str, initial_prompt: str | None = None
+) -> dict:
+    """Spawn a coding agent in a worktree.
+
+    The agent runs with skip_permissions=True. Only one agent can run
+    per worktree at a time.
+
+    Args:
+        worktree_path: Absolute path of the worktree.
+        initial_prompt: Optional initial prompt to send to the agent after it starts.
+
+    Returns:
+        Object with worktree_path and status.
+    """
+    params: dict[str, Any] = {"worktree_path": worktree_path}
+    if initial_prompt is not None:
+        params["initial_prompt"] = initial_prompt
+    return await _get_client().call("spawn_agent", params)
+
+
+@mcp.tool()
+async def stop_agent(worktree_path: str) -> dict:
+    """Stop the running agent in a worktree.
+
+    Args:
+        worktree_path: Absolute path of the worktree.
+
+    Returns:
+        Object confirming the agent was stopped.
+    """
+    return await _get_client().call(
+        "stop_agent",
+        {"worktree_path": worktree_path},
+    )
+
+
+@mcp.tool()
+async def get_agent_status(worktree_path: str) -> dict:
+    """Get the current status of the agent in a worktree.
+
+    Args:
+        worktree_path: Absolute path of the worktree.
+
+    Returns:
+        Object with status, confidence, and detail fields.
+    """
+    return await _get_client().call(
+        "get_agent_status",
+        {"worktree_path": worktree_path},
+    )
+
+
+@mcp.tool()
+async def read_agent_output(worktree_path: str, lines: int = 50) -> dict:
+    """Read recent terminal output from the agent in a worktree.
+
+    Includes both scrollback history and the current live screen buffer.
+
+    Args:
+        worktree_path: Absolute path of the worktree.
+        lines: Number of recent lines to return (default 50).
+
+    Returns:
+        Object with lines (list of strings), total_lines count, and worktree_path.
+    """
+    return await _get_client().call(
+        "read_agent_output",
+        {"worktree_path": worktree_path, "lines": lines},
+    )
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/src/lazyagent/orchestrator_prompt.py
+++ b/src/lazyagent/orchestrator_prompt.py
@@ -1,0 +1,159 @@
+"""Default system prompt and composition logic for the orchestrator agent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lazyagent.config import Config
+
+DEFAULT_USER_PROMPT_FILE = ".lazyagent-orchestrator.md"
+
+DEFAULT_ORCHESTRATOR_PROMPT = """\
+You are the **lazyagent orchestrator**, a supervisory coding agent that manages \
+parallel workstreams across git worktrees. All coordination happens through MCP \
+tool calls — you never run git commands directly.
+
+## How it works
+
+Each task runs in its own **git worktree** — an isolated checkout of the same \
+repository with its own branch. You create worktrees, spawn agents inside them, \
+monitor progress, and clean up when done.
+
+Agents are **headless coding CLI sessions** (Claude Code, Codex, Gemini CLI) that \
+run inside a terminal. They can read/write files, run commands, and make commits — \
+but only within their own worktree. They cannot see each other.
+
+You are the only one with a global view. Use that to coordinate.
+
+## MCP tool reference
+
+### Worktree management
+
+- **`list_worktrees`** — Returns all worktrees with branch, path, agent status, \
+and git status. Call this first to understand current state.
+- **`create_worktree(branch, base_branch="main")`** — Creates a new worktree on \
+a new branch forked from `base_branch`. Use descriptive branch names \
+(e.g., `fix-auth-redirect`, `add-user-export`).
+- **`remove_worktree(worktree_path, force=false)`** — Removes a worktree. Will \
+fail if an agent is running — stop it first.
+
+### Agent lifecycle
+
+- **`spawn_agent(worktree_path, instruction?)`** — Starts a coding agent in the \
+given worktree. The `instruction` is the task prompt the agent will execute. Make \
+it specific and self-contained — the agent has no context beyond what you write here.
+- **`stop_agent(worktree_path)`** — Kills the agent process. Use when an agent is \
+stuck, went off-track, or the task is done.
+- **`get_agent_status(worktree_path)`** — Returns status (`running`, `waiting`, \
+`idle`, `no_agent`), confidence level, and detail text.
+- **`read_agent_output(worktree_path, lines=50)`** — Reads recent terminal output. \
+Use this to check progress, see errors, or verify completion.
+
+## Workflow
+
+### 1. Assess
+
+Call `list_worktrees` to see what exists, what's running, and what branches are active.
+
+### 2. Plan
+
+For each task the user gives you:
+- Decide: reuse an existing idle worktree, or create a new one?
+- Draft clear, atomic instructions for each agent.
+- Present the plan to the user. Wait for approval before spawning agents.
+
+### 3. Execute
+
+Create worktrees and spawn agents with clear instructions:
+```
+create_worktree(branch="fix-login-bug", base_branch="main")
+spawn_agent(worktree_path="/path/to/worktree", instruction="...")
+```
+
+### 4. Monitor
+
+Poll periodically:
+```
+get_agent_status(worktree_path)  →  is it running? waiting? done?
+read_agent_output(worktree_path)  →  what has it done so far?
+```
+
+If an agent is **waiting for approval** or **stuck**:
+- Read its output to understand the situation.
+- If you can resolve it, stop and re-spawn with refined instructions.
+- If it needs human judgement, escalate to the user.
+
+### 5. Verify & clean up
+
+When an agent finishes:
+- `read_agent_output` to verify the work looks correct.
+- Report the result to the user.
+- Optionally `remove_worktree` if the branch has been merged or is no longer needed.
+
+## Writing good agent instructions
+
+The instruction you pass to `spawn_agent` is the **only context** the agent gets. \
+Make it count:
+
+- **Be specific.** "Fix the login redirect bug in `src/auth/login.py` — the \
+redirect URL is not URL-encoded" is better than "fix the login bug".
+- **Be self-contained.** Include file paths, function names, expected behavior.
+- **One task per agent.** Don't combine unrelated changes.
+- **Include verification.** "Run `pytest tests/test_auth.py` to verify the fix" \
+helps the agent validate its own work.
+
+## Rules
+
+- Always call `list_worktrees` before creating or removing worktrees.
+- Never remove a worktree with a running agent — `stop_agent` first.
+- Never spawn into a worktree that already has a running agent.
+- Prefer reusing existing idle worktrees over creating new ones.
+- Spawn agents sequentially unless the user explicitly asks for parallel execution.
+- When uncertain about scope or approach, ask the user rather than guessing.
+- Keep the user informed of progress at natural milestones (agent spawned, agent \
+finished, error encountered).
+"""
+
+
+def compose_orchestrator_prompt(config: Config, repo_root: str | Path) -> str:
+    """Build the full orchestrator system prompt from all layers.
+
+    Layers (in order):
+    1. Default prompt (always included)
+    2. Agent instruction template section (from config, if set)
+    3. User prompt file content (if the file exists)
+    """
+    parts: list[str] = [DEFAULT_ORCHESTRATOR_PROMPT]
+
+    template_section = _format_template_section(config)
+    if template_section:
+        parts.append(template_section)
+
+    user_prompt = _load_user_prompt(config, repo_root)
+    if user_prompt:
+        parts.append(user_prompt)
+
+    return "\n".join(parts)
+
+
+def _load_user_prompt(config: Config, repo_root: str | Path) -> str | None:
+    """Read the user prompt file from the repo root. Returns None if missing."""
+    filename = config.orchestrator.prompt_file or DEFAULT_USER_PROMPT_FILE
+    path = Path(repo_root) / filename
+    try:
+        return path.read_text(encoding="utf-8").strip() or None
+    except (FileNotFoundError, OSError):
+        return None
+
+
+def _format_template_section(config: Config) -> str | None:
+    """Format the agent instruction template as a prompt section."""
+    template = config.orchestrator.agent_instruction_template
+    if not template:
+        return None
+    return (
+        "## Agent instruction template\n\n"
+        "When spawning agents, use the following template for their instructions "
+        "(substitute placeholders as appropriate):\n\n"
+        f"```\n{template}\n```"
+    )

--- a/src/lazyagent/widgets/center_panel.py
+++ b/src/lazyagent/widgets/center_panel.py
@@ -242,7 +242,7 @@ class WorktreePanel(Container):
         skip_permissions: bool = False,
         agent_provider: str = DEFAULT_AGENT_PROVIDER,
         resume_mode: ResumeMode = ResumeMode.NEW,
-        instruction: str = "",
+        instruction: str | None = None,
     ) -> None:
         """Spawn the configured coding agent process in the Agent pane."""
         pane = self.query_one("#agent-tab", TabPane)
@@ -267,7 +267,7 @@ class WorktreePanel(Container):
             skip_permissions=skip_permissions,
             runtime_context=runtime_context,
             resume_mode=resume_mode,
-            instruction=instruction or None,
+            instruction=instruction,
         )
 
         terminal = MonitoredTerminal(

--- a/src/lazyagent/widgets/center_panel.py
+++ b/src/lazyagent/widgets/center_panel.py
@@ -316,66 +316,58 @@ class CenterPanel(Container):
         )
         yield ContentSwitcher(id="panel-switcher", initial=None)
 
+    def _get_panel_by_key(self, key: str) -> Container | None:
+        """Get an existing panel by key, or None."""
+        if key not in self._panels:
+            return None
+        panel_id = self._panels[key]
+        return self.query_one(f"#{panel_id}", Container)
+
+    def _activate_panel(self, key: str) -> None:
+        """Hide placeholder and switch the ContentSwitcher to the given key."""
+        self.query_one("#center-placeholder", Static).display = False
+        self.query_one("#panel-switcher", ContentSwitcher).current = self._panels[key]
+
     def ensure_panel(self, worktree_path: str) -> WorktreePanel:
         """Get or lazily create a WorktreePanel for the given worktree."""
-        if worktree_path in self._panels:
-            panel_id = self._panels[worktree_path]
-            return self.query_one(f"#{panel_id}", WorktreePanel)
+        existing = self._get_panel_by_key(worktree_path)
+        if existing is not None:
+            return existing  # type: ignore[return-value]
 
         panel_id = _panel_id(worktree_path)
         panel = WorktreePanel(worktree_path, id=panel_id)
-        switcher = self.query_one("#panel-switcher", ContentSwitcher)
-        switcher.mount(panel)
+        self.query_one("#panel-switcher", ContentSwitcher).mount(panel)
         self._panels[worktree_path] = panel_id
         return panel
 
     def switch_to(self, worktree_path: str) -> WorktreePanel:
         """Switch the visible panel to the given worktree (creating if needed)."""
         panel = self.ensure_panel(worktree_path)
-        panel_id = self._panels[worktree_path]
-
-        placeholder = self.query_one("#center-placeholder", Static)
-        placeholder.display = False
-
-        switcher = self.query_one("#panel-switcher", ContentSwitcher)
-        switcher.current = panel_id
+        self._activate_panel(worktree_path)
         return panel
 
     def get_panel(self, worktree_path: str) -> WorktreePanel | None:
-        """Get existing panel or None."""
-        if worktree_path not in self._panels:
-            return None
-        panel_id = self._panels[worktree_path]
-        return self.query_one(f"#{panel_id}", WorktreePanel)
+        """Get existing WorktreePanel or None."""
+        return self._get_panel_by_key(worktree_path)  # type: ignore[return-value]
 
-    def ensure_orchestrator_panel(self) -> OrchestratorPanel:
+    def ensure_orchestrator_panel(self, repo_root: str) -> OrchestratorPanel:
         """Get or lazily create the OrchestratorPanel."""
-        if ORCHESTRATOR_KEY in self._panels:
-            panel_id = self._panels[ORCHESTRATOR_KEY]
-            return self.query_one(f"#{panel_id}", OrchestratorPanel)
+        existing = self._get_panel_by_key(ORCHESTRATOR_KEY)
+        if existing is not None:
+            return existing  # type: ignore[return-value]
 
         panel_id = "wp-orchestrator"
-        panel = OrchestratorPanel(id=panel_id)
-        switcher = self.query_one("#panel-switcher", ContentSwitcher)
-        switcher.mount(panel)
+        panel = OrchestratorPanel(worktree_path=repo_root, id=panel_id)
+        self.query_one("#panel-switcher", ContentSwitcher).mount(panel)
         self._panels[ORCHESTRATOR_KEY] = panel_id
         return panel
 
-    def switch_to_orchestrator(self) -> OrchestratorPanel:
+    def switch_to_orchestrator(self, repo_root: str) -> OrchestratorPanel:
         """Switch the visible panel to the orchestrator."""
-        panel = self.ensure_orchestrator_panel()
-        panel_id = self._panels[ORCHESTRATOR_KEY]
-
-        placeholder = self.query_one("#center-placeholder", Static)
-        placeholder.display = False
-
-        switcher = self.query_one("#panel-switcher", ContentSwitcher)
-        switcher.current = panel_id
+        panel = self.ensure_orchestrator_panel(repo_root)
+        self._activate_panel(ORCHESTRATOR_KEY)
         return panel
 
     def get_orchestrator_panel(self) -> OrchestratorPanel | None:
         """Get the orchestrator panel if it exists."""
-        if ORCHESTRATOR_KEY not in self._panels:
-            return None
-        panel_id = self._panels[ORCHESTRATOR_KEY]
-        return self.query_one(f"#{panel_id}", OrchestratorPanel)
+        return self._get_panel_by_key(ORCHESTRATOR_KEY)  # type: ignore[return-value]

--- a/src/lazyagent/widgets/center_panel.py
+++ b/src/lazyagent/widgets/center_panel.py
@@ -16,6 +16,7 @@ from lazyagent.agent_providers import (
 from lazyagent.models import GitStatus
 from lazyagent.styles import SCROLLBAR_CSS
 from lazyagent.widgets.monitored_terminal import MonitoredTerminal
+from lazyagent.widgets.orchestrator_panel import ORCHESTRATOR_KEY, OrchestratorPanel
 from lazyagent.widgets.scrollable_terminal import ScrollableTerminal
 
 
@@ -346,3 +347,35 @@ class CenterPanel(Container):
             return None
         panel_id = self._panels[worktree_path]
         return self.query_one(f"#{panel_id}", WorktreePanel)
+
+    def ensure_orchestrator_panel(self) -> OrchestratorPanel:
+        """Get or lazily create the OrchestratorPanel."""
+        if ORCHESTRATOR_KEY in self._panels:
+            panel_id = self._panels[ORCHESTRATOR_KEY]
+            return self.query_one(f"#{panel_id}", OrchestratorPanel)
+
+        panel_id = "wp-orchestrator"
+        panel = OrchestratorPanel(id=panel_id)
+        switcher = self.query_one("#panel-switcher", ContentSwitcher)
+        switcher.mount(panel)
+        self._panels[ORCHESTRATOR_KEY] = panel_id
+        return panel
+
+    def switch_to_orchestrator(self) -> OrchestratorPanel:
+        """Switch the visible panel to the orchestrator."""
+        panel = self.ensure_orchestrator_panel()
+        panel_id = self._panels[ORCHESTRATOR_KEY]
+
+        placeholder = self.query_one("#center-placeholder", Static)
+        placeholder.display = False
+
+        switcher = self.query_one("#panel-switcher", ContentSwitcher)
+        switcher.current = panel_id
+        return panel
+
+    def get_orchestrator_panel(self) -> OrchestratorPanel | None:
+        """Get the orchestrator panel if it exists."""
+        if ORCHESTRATOR_KEY not in self._panels:
+            return None
+        panel_id = self._panels[ORCHESTRATOR_KEY]
+        return self.query_one(f"#{panel_id}", OrchestratorPanel)

--- a/src/lazyagent/widgets/center_panel.py
+++ b/src/lazyagent/widgets/center_panel.py
@@ -242,6 +242,7 @@ class WorktreePanel(Container):
         skip_permissions: bool = False,
         agent_provider: str = DEFAULT_AGENT_PROVIDER,
         resume_mode: ResumeMode = ResumeMode.NEW,
+        socket_path: str | None = None,
     ) -> None:
         """Spawn the configured coding agent process in the Agent pane."""
         pane = self.query_one("#agent-tab", TabPane)
@@ -260,7 +261,9 @@ class WorktreePanel(Container):
             pass
 
         provider = get_agent_provider(agent_provider)
-        runtime_context = provider.build_runtime_context(self.worktree_path)
+        runtime_context = provider.build_runtime_context(
+            self.worktree_path, socket_path=socket_path
+        )
         command = provider.build_command(
             self.worktree_path,
             skip_permissions=skip_permissions,

--- a/src/lazyagent/widgets/center_panel.py
+++ b/src/lazyagent/widgets/center_panel.py
@@ -242,6 +242,7 @@ class WorktreePanel(Container):
         skip_permissions: bool = False,
         agent_provider: str = DEFAULT_AGENT_PROVIDER,
         resume_mode: ResumeMode = ResumeMode.NEW,
+        instruction: str = "",
     ) -> None:
         """Spawn the configured coding agent process in the Agent pane."""
         pane = self.query_one("#agent-tab", TabPane)
@@ -266,6 +267,7 @@ class WorktreePanel(Container):
             skip_permissions=skip_permissions,
             runtime_context=runtime_context,
             resume_mode=resume_mode,
+            instruction=instruction or None,
         )
 
         terminal = MonitoredTerminal(

--- a/src/lazyagent/widgets/orchestrator_panel.py
+++ b/src/lazyagent/widgets/orchestrator_panel.py
@@ -69,6 +69,7 @@ class OrchestratorPanel(Container):
         resume_mode: ResumeMode = ResumeMode.NEW,
         socket_path: str | None = None,
         instruction: str | None = None,
+        system_prompt: str | None = None,
     ) -> None:
         """Spawn the orchestrator agent process."""
         # Remove previous terminal or placeholder
@@ -93,6 +94,7 @@ class OrchestratorPanel(Container):
             runtime_context=runtime_context,
             resume_mode=resume_mode,
             instruction=instruction,
+            system_prompt=system_prompt,
         )
 
         terminal = MonitoredTerminal(

--- a/src/lazyagent/widgets/orchestrator_panel.py
+++ b/src/lazyagent/widgets/orchestrator_panel.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from textual.containers import Container
+from textual.widgets import Static
+
+from lazyagent.agent_providers import (
+    DEFAULT_AGENT_PROVIDER,
+    ResumeMode,
+    env_exports,
+    get_agent_provider,
+)
+from lazyagent.widgets.monitored_terminal import MonitoredTerminal
+
+ORCHESTRATOR_KEY = "__orchestrator__"
+
+
+class OrchestratorPanel(Container):
+    """Simplified center panel for the orchestrator — just a single MonitoredTerminal."""
+
+    DEFAULT_CSS = """
+    OrchestratorPanel {
+        layout: vertical;
+        width: 1fr;
+        height: 1fr;
+    }
+    #orch-placeholder {
+        width: 1fr;
+        height: 1fr;
+        content-align: center middle;
+        color: $text-muted;
+    }
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._agent_terminal: MonitoredTerminal | None = None
+
+    def compose(self):
+        yield Static(
+            "Press [bold]s[/bold] to spawn orchestrator",
+            id="orch-placeholder",
+        )
+
+    @property
+    def agent_terminal(self) -> MonitoredTerminal | None:
+        return self._agent_terminal
+
+    @property
+    def has_agent(self) -> bool:
+        return (
+            self._agent_terminal is not None
+            and self._agent_terminal.emulator is not None
+        )
+
+    async def cleanup_agent(self) -> None:
+        """Remove the agent terminal and restore the placeholder."""
+        if self._agent_terminal is not None:
+            self._agent_terminal.stop()
+            await self._agent_terminal.remove()
+            self._agent_terminal = None
+
+        try:
+            self.query_one("#orch-placeholder")
+        except Exception:
+            self.mount(
+                Static(
+                    "Press [bold]s[/bold] to spawn orchestrator",
+                    id="orch-placeholder",
+                )
+            )
+
+    async def spawn_agent(
+        self,
+        worktree_path: str,
+        skip_permissions: bool = False,
+        agent_provider: str = DEFAULT_AGENT_PROVIDER,
+        resume_mode: ResumeMode = ResumeMode.NEW,
+        socket_path: str | None = None,
+        instruction: str | None = None,
+    ) -> None:
+        """Spawn the orchestrator agent process."""
+        # Remove previous terminal or placeholder
+        if self._agent_terminal is not None:
+            self._agent_terminal.stop()
+            await self._agent_terminal.remove()
+            self._agent_terminal = None
+
+        try:
+            placeholder = self.query_one("#orch-placeholder", Static)
+            await placeholder.remove()
+        except Exception:
+            pass
+
+        provider = get_agent_provider(agent_provider)
+        runtime_context = provider.build_runtime_context(
+            worktree_path, socket_path=socket_path
+        )
+        command = provider.build_command(
+            worktree_path,
+            skip_permissions=skip_permissions,
+            runtime_context=runtime_context,
+            resume_mode=resume_mode,
+            instruction=instruction,
+        )
+
+        terminal = MonitoredTerminal(
+            command=command,
+            worktree_path=ORCHESTRATOR_KEY,
+            observer=provider.create_observer_from_context(runtime_context),
+            id="orch-agent-terminal",
+        )
+        self._agent_terminal = terminal
+        self.mount(terminal)
+        terminal.start()
+        terminal.focus()

--- a/src/lazyagent/widgets/orchestrator_panel.py
+++ b/src/lazyagent/widgets/orchestrator_panel.py
@@ -6,12 +6,12 @@ from textual.widgets import Static
 from lazyagent.agent_providers import (
     DEFAULT_AGENT_PROVIDER,
     ResumeMode,
-    env_exports,
     get_agent_provider,
 )
 from lazyagent.widgets.monitored_terminal import MonitoredTerminal
 
 ORCHESTRATOR_KEY = "__orchestrator__"
+_PLACEHOLDER_TEXT = "Press [bold]s[/bold] to spawn orchestrator"
 
 
 class OrchestratorPanel(Container):
@@ -31,15 +31,13 @@ class OrchestratorPanel(Container):
     }
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, worktree_path: str, **kwargs) -> None:
         super().__init__(**kwargs)
+        self.worktree_path = worktree_path
         self._agent_terminal: MonitoredTerminal | None = None
 
     def compose(self):
-        yield Static(
-            "Press [bold]s[/bold] to spawn orchestrator",
-            id="orch-placeholder",
-        )
+        yield Static(_PLACEHOLDER_TEXT, id="orch-placeholder")
 
     @property
     def agent_terminal(self) -> MonitoredTerminal | None:
@@ -62,16 +60,10 @@ class OrchestratorPanel(Container):
         try:
             self.query_one("#orch-placeholder")
         except Exception:
-            self.mount(
-                Static(
-                    "Press [bold]s[/bold] to spawn orchestrator",
-                    id="orch-placeholder",
-                )
-            )
+            self.mount(Static(_PLACEHOLDER_TEXT, id="orch-placeholder"))
 
     async def spawn_agent(
         self,
-        worktree_path: str,
         skip_permissions: bool = False,
         agent_provider: str = DEFAULT_AGENT_PROVIDER,
         resume_mode: ResumeMode = ResumeMode.NEW,
@@ -93,10 +85,10 @@ class OrchestratorPanel(Container):
 
         provider = get_agent_provider(agent_provider)
         runtime_context = provider.build_runtime_context(
-            worktree_path, socket_path=socket_path
+            self.worktree_path, socket_path=socket_path
         )
         command = provider.build_command(
-            worktree_path,
+            self.worktree_path,
             skip_permissions=skip_permissions,
             runtime_context=runtime_context,
             resume_mode=resume_mode,

--- a/src/lazyagent/widgets/prompt_modal.py
+++ b/src/lazyagent/widgets/prompt_modal.py
@@ -15,7 +15,7 @@ from lazyagent.agent_providers import DEFAULT_AGENT_PROVIDER, ResumeMode, get_ag
 class SpawnResult:
     skip_permissions: bool
     resume_mode: ResumeMode = ResumeMode.NEW
-    instruction: str = ""
+    instruction: str | None = None
 
 
 _LABELS_DISTINCT: dict[ResumeMode, str] = {

--- a/src/lazyagent/widgets/prompt_modal.py
+++ b/src/lazyagent/widgets/prompt_modal.py
@@ -15,6 +15,7 @@ from lazyagent.agent_providers import DEFAULT_AGENT_PROVIDER, ResumeMode, get_ag
 class SpawnResult:
     skip_permissions: bool
     resume_mode: ResumeMode = ResumeMode.NEW
+    instruction: str = ""
 
 
 _LABELS_DISTINCT: dict[ResumeMode, str] = {

--- a/src/lazyagent/widgets/scrollable_terminal.py
+++ b/src/lazyagent/widgets/scrollable_terminal.py
@@ -639,35 +639,11 @@ class ScrollableTerminal(ScrollView, can_focus=True):
             for x in range(self._screen.columns)
         ).rstrip()
 
-    def _get_text_line(self, virtual_y: int) -> str:
-        """Get text content of a single virtual line."""
-        scrollback_len = len(self._screen.scrollback)
-        if virtual_y < scrollback_len:
-            return self._row_to_text(self._screen.scrollback[virtual_y])
-        return self._row_to_text(self._screen.buffer[virtual_y - scrollback_len])
-
     def _extract_selection(self, selection: Selection) -> tuple[str, str] | None:
         """Extract text from scrollback + screen buffer for a selection."""
-        if self._sel_start is not None and self._sel_end is not None:
-            # Optimized path: only process the rows within the selection range
-            min_y = min(self._sel_start.y, self._sel_end.y)
-            max_y = max(self._sel_start.y, self._sel_end.y)
-            total_lines = len(self._screen.scrollback) + self._screen.lines
-            min_y = max(0, min_y)
-            max_y = min(max_y, total_lines - 1)
-
-            lines = [self._get_text_line(y) for y in range(min_y, max_y + 1)]
-            partial_text = "\n".join(lines)
-
-            # Adjust selection to be relative to the partial text
-            adjusted_start = Offset(self._sel_start.x, self._sel_start.y - min_y)
-            adjusted_end = Offset(self._sel_end.x, self._sel_end.y - min_y)
-            adjusted_sel = Selection.from_offsets(adjusted_start, adjusted_end)
-            return adjusted_sel.extract(partial_text), "\n"
-
-        # Fallback: full buffer extraction (e.g. Selection with start=None)
-        total = len(self._screen.scrollback) + self._screen.lines
-        lines = [self._get_text_line(y) for y in range(total)]
+        lines = [self._row_to_text(row) for row in self._screen.scrollback]
+        for y in range(self._screen.lines):
+            lines.append(self._row_to_text(self._screen.buffer[y]))
         full_text = "\n".join(lines)
         return selection.extract(full_text), "\n"
 

--- a/src/lazyagent/widgets/scrollable_terminal.py
+++ b/src/lazyagent/widgets/scrollable_terminal.py
@@ -639,11 +639,35 @@ class ScrollableTerminal(ScrollView, can_focus=True):
             for x in range(self._screen.columns)
         ).rstrip()
 
+    def _get_text_line(self, virtual_y: int) -> str:
+        """Get text content of a single virtual line."""
+        scrollback_len = len(self._screen.scrollback)
+        if virtual_y < scrollback_len:
+            return self._row_to_text(self._screen.scrollback[virtual_y])
+        return self._row_to_text(self._screen.buffer[virtual_y - scrollback_len])
+
     def _extract_selection(self, selection: Selection) -> tuple[str, str] | None:
         """Extract text from scrollback + screen buffer for a selection."""
-        lines = [self._row_to_text(row) for row in self._screen.scrollback]
-        for y in range(self._screen.lines):
-            lines.append(self._row_to_text(self._screen.buffer[y]))
+        if self._sel_start is not None and self._sel_end is not None:
+            # Optimized path: only process the rows within the selection range
+            min_y = min(self._sel_start.y, self._sel_end.y)
+            max_y = max(self._sel_start.y, self._sel_end.y)
+            total_lines = len(self._screen.scrollback) + self._screen.lines
+            min_y = max(0, min_y)
+            max_y = min(max_y, total_lines - 1)
+
+            lines = [self._get_text_line(y) for y in range(min_y, max_y + 1)]
+            partial_text = "\n".join(lines)
+
+            # Adjust selection to be relative to the partial text
+            adjusted_start = Offset(self._sel_start.x, self._sel_start.y - min_y)
+            adjusted_end = Offset(self._sel_end.x, self._sel_end.y - min_y)
+            adjusted_sel = Selection.from_offsets(adjusted_start, adjusted_end)
+            return adjusted_sel.extract(partial_text), "\n"
+
+        # Fallback: full buffer extraction (e.g. Selection with start=None)
+        total = len(self._screen.scrollback) + self._screen.lines
+        lines = [self._get_text_line(y) for y in range(total)]
         full_text = "\n".join(lines)
         return selection.extract(full_text), "\n"
 
@@ -667,11 +691,9 @@ class ScrollableTerminal(ScrollView, can_focus=True):
 
     @staticmethod
     def _copy_to_system_clipboard(text: str, cmd: list[str]) -> None:
-        """Copy text to system clipboard (fire-and-forget)."""
+        """Copy text to system clipboard."""
         try:
-            proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
-            proc.stdin.write(text.encode())
-            proc.stdin.close()
+            subprocess.run(cmd, input=text.encode(), check=False, timeout=5)
         except Exception:
             pass
 

--- a/src/lazyagent/widgets/worktree_list.py
+++ b/src/lazyagent/widgets/worktree_list.py
@@ -4,6 +4,78 @@ from textual.binding import Binding
 from textual.widgets import ListItem, ListView, Static
 
 from lazyagent.models import AgentState, AgentStatus, GitStatus, LifecycleConfidence, WorktreeInfo
+from lazyagent.widgets.orchestrator_panel import ORCHESTRATOR_KEY
+
+
+class OrchestratorListItem(ListItem):
+    """Special first entry in the sidebar for the orchestrator agent."""
+
+    DEFAULT_CSS = """
+    OrchestratorListItem {
+        height: 2;
+        padding: 0 1;
+        color: $text;
+        background: $primary-background-darken-1;
+        border-left: tall $warning;
+    }
+    OrchestratorListItem.-highlight {
+        background: $boost;
+    }
+    """
+
+    def __init__(self, agent_state: AgentState | None = None) -> None:
+        super().__init__()
+        self._agent_state = agent_state or AgentState()
+
+    def compose(self):
+        yield Static(self._build_label(), markup=True, id="orch-label")
+
+    def _build_label(self) -> str:
+        status = self._status_line()
+        return f"[bold]ORCH[/bold]\n{status}"
+
+    def _status_line(self) -> str:
+        state = self._agent_state
+        status = state.status
+        conf = state.confidence
+
+        def _fmt(text: str, color: str) -> str:
+            if conf == LifecycleConfidence.LOW:
+                return f"[dim {color}]{text}[/dim {color}]"
+            return f"[{color}]{text}[/{color}]"
+
+        if status == AgentStatus.NO_AGENT:
+            return "[dim]---[/dim]"
+
+        res = ""
+        if status == AgentStatus.RUNNING:
+            res = _fmt("running", "green")
+        elif status in (AgentStatus.WAITING, AgentStatus.WAITING_FOR_USER):
+            res = _fmt("waiting", "bold yellow")
+        elif status == AgentStatus.WAITING_FOR_APPROVAL:
+            res = _fmt("approving", "bold yellow")
+        elif status == AgentStatus.COMPLETED:
+            res = _fmt("completed", "bold cyan")
+        elif status == AgentStatus.FAILED:
+            res = _fmt("failed", "bold red")
+        elif status == AgentStatus.INTERRUPTED:
+            res = _fmt("interrupted", "dim red")
+        elif status == AgentStatus.POSSIBLY_HANGED:
+            res = "[bold red]hanged?[/bold red]"
+
+        if state.detail and status not in (AgentStatus.RUNNING, AgentStatus.NO_AGENT):
+            res += f" [dim]({state.detail})[/dim]"
+
+        return res or "[dim]---[/dim]"
+
+    def update_agent_state(self, state: AgentState) -> None:
+        """Re-render the label with updated agent state."""
+        self._agent_state = state
+        try:
+            label_widget = self.query_one("#orch-label", Static)
+            label_widget.update(self._build_label())
+        except Exception:
+            pass
 
 
 class WorktreeListItem(ListItem):
@@ -139,9 +211,17 @@ class WorktreeList(ListView):
         """Replace the list contents with the given worktrees, restoring agent state if provided."""
         self.clear()
         agent_states = agent_states or {}
+        self.append(OrchestratorListItem(agent_state=agent_states.get(ORCHESTRATOR_KEY)))
         for wt in worktrees:
             state = agent_states.get(wt.path)
             self.append(WorktreeListItem(wt, agent_state=state))
+
+    def update_orchestrator_state(self, state: AgentState) -> None:
+        """Update the orchestrator list item's agent state."""
+        for child in self.children:
+            if isinstance(child, OrchestratorListItem):
+                child.update_agent_state(state)
+                break
 
     def update_agent_state(self, worktree_path: str, state: AgentState) -> None:
         """Find the item for the given worktree path and update its agent state."""

--- a/src/lazyagent/widgets/worktree_list.py
+++ b/src/lazyagent/widgets/worktree_list.py
@@ -7,6 +7,41 @@ from lazyagent.models import AgentState, AgentStatus, GitStatus, LifecycleConfid
 from lazyagent.widgets.orchestrator_panel import ORCHESTRATOR_KEY
 
 
+def format_agent_status(state: AgentState) -> str:
+    """Format an AgentState into a Rich-markup status string."""
+    status = state.status
+    conf = state.confidence
+
+    def _fmt(text: str, color: str) -> str:
+        if conf == LifecycleConfidence.LOW:
+            return f"[dim {color}]{text}[/dim {color}]"
+        return f"[{color}]{text}[/{color}]"
+
+    if status == AgentStatus.NO_AGENT:
+        return "[dim]---[/dim]"
+
+    res = ""
+    if status == AgentStatus.RUNNING:
+        res = _fmt("running", "green")
+    elif status in (AgentStatus.WAITING, AgentStatus.WAITING_FOR_USER):
+        res = _fmt("waiting", "bold yellow")
+    elif status == AgentStatus.WAITING_FOR_APPROVAL:
+        res = _fmt("approving", "bold yellow")
+    elif status == AgentStatus.COMPLETED:
+        res = _fmt("completed", "bold cyan")
+    elif status == AgentStatus.FAILED:
+        res = _fmt("failed", "bold red")
+    elif status == AgentStatus.INTERRUPTED:
+        res = _fmt("interrupted", "dim red")
+    elif status == AgentStatus.POSSIBLY_HANGED:
+        res = "[bold red]hanged?[/bold red]"
+
+    if state.detail and status not in (AgentStatus.RUNNING, AgentStatus.NO_AGENT):
+        res += f" [dim]({state.detail})[/dim]"
+
+    return res or "[dim]---[/dim]"
+
+
 class OrchestratorListItem(ListItem):
     """Special first entry in the sidebar for the orchestrator agent."""
 
@@ -31,42 +66,7 @@ class OrchestratorListItem(ListItem):
         yield Static(self._build_label(), markup=True, id="orch-label")
 
     def _build_label(self) -> str:
-        status = self._status_line()
-        return f"[bold]ORCH[/bold]\n{status}"
-
-    def _status_line(self) -> str:
-        state = self._agent_state
-        status = state.status
-        conf = state.confidence
-
-        def _fmt(text: str, color: str) -> str:
-            if conf == LifecycleConfidence.LOW:
-                return f"[dim {color}]{text}[/dim {color}]"
-            return f"[{color}]{text}[/{color}]"
-
-        if status == AgentStatus.NO_AGENT:
-            return "[dim]---[/dim]"
-
-        res = ""
-        if status == AgentStatus.RUNNING:
-            res = _fmt("running", "green")
-        elif status in (AgentStatus.WAITING, AgentStatus.WAITING_FOR_USER):
-            res = _fmt("waiting", "bold yellow")
-        elif status == AgentStatus.WAITING_FOR_APPROVAL:
-            res = _fmt("approving", "bold yellow")
-        elif status == AgentStatus.COMPLETED:
-            res = _fmt("completed", "bold cyan")
-        elif status == AgentStatus.FAILED:
-            res = _fmt("failed", "bold red")
-        elif status == AgentStatus.INTERRUPTED:
-            res = _fmt("interrupted", "dim red")
-        elif status == AgentStatus.POSSIBLY_HANGED:
-            res = "[bold red]hanged?[/bold red]"
-
-        if state.detail and status not in (AgentStatus.RUNNING, AgentStatus.NO_AGENT):
-            res += f" [dim]({state.detail})[/dim]"
-
-        return res or "[dim]---[/dim]"
+        return f"[bold]ORCH[/bold]\n{format_agent_status(self._agent_state)}"
 
     def update_agent_state(self, state: AgentState) -> None:
         """Re-render the label with updated agent state."""
@@ -110,44 +110,9 @@ class WorktreeListItem(ListItem):
     def _build_label(self) -> str:
         label = self.worktree.display_label
         branch = self.worktree.display_branch
-        status = self._status_line()
+        status = format_agent_status(self._agent_state)
         git = self._git_status_line()
         return f"[bold]{label}[/bold]\n{branch}\n{status}\n{git}"
-
-    def _status_line(self) -> str:
-        state = self._agent_state
-        status = state.status
-        conf = state.confidence
-        detail = state.detail
-
-        def _fmt(text: str, color: str) -> str:
-            if conf == LifecycleConfidence.LOW:
-                return f"[dim {color}]{text}[/dim {color}]"
-            return f"[{color}]{text}[/{color}]"
-
-        if status == AgentStatus.NO_AGENT:
-            return "[dim]---[/dim]"
-
-        res = ""
-        if status == AgentStatus.RUNNING:
-            res = _fmt("running", "green")
-        elif status in (AgentStatus.WAITING, AgentStatus.WAITING_FOR_USER):
-            res = _fmt("waiting", "bold yellow")
-        elif status == AgentStatus.WAITING_FOR_APPROVAL:
-            res = _fmt("approving", "bold yellow")
-        elif status == AgentStatus.COMPLETED:
-            res = _fmt("completed", "bold cyan")
-        elif status == AgentStatus.FAILED:
-            res = _fmt("failed", "bold red")
-        elif status == AgentStatus.INTERRUPTED:
-            res = _fmt("interrupted", "dim red")
-        elif status == AgentStatus.POSSIBLY_HANGED:
-            res = "[bold red]hanged?[/bold red]"
-
-        if detail and status not in (AgentStatus.RUNNING, AgentStatus.NO_AGENT):
-            res += f" [dim]({detail})[/dim]"
-
-        return res or "[dim]---[/dim]"
 
     def _git_status_line(self) -> str:
         gs = self._git_status
@@ -216,19 +181,18 @@ class WorktreeList(ListView):
             state = agent_states.get(wt.path)
             self.append(WorktreeListItem(wt, agent_state=state))
 
-    def update_orchestrator_state(self, state: AgentState) -> None:
-        """Update the orchestrator list item's agent state."""
-        for child in self.children:
-            if isinstance(child, OrchestratorListItem):
-                child.update_agent_state(state)
-                break
-
-    def update_agent_state(self, worktree_path: str, state: AgentState) -> None:
-        """Find the item for the given worktree path and update its agent state."""
-        for child in self.children:
-            if isinstance(child, WorktreeListItem) and child.worktree.path == worktree_path:
-                child.update_agent_state(state)
-                break
+    def update_agent_state(self, key: str, state: AgentState) -> None:
+        """Update the sidebar item for the given key (worktree path or ORCHESTRATOR_KEY)."""
+        if key == ORCHESTRATOR_KEY:
+            for child in self.children:
+                if isinstance(child, OrchestratorListItem):
+                    child.update_agent_state(state)
+                    break
+        else:
+            for child in self.children:
+                if isinstance(child, WorktreeListItem) and child.worktree.path == key:
+                    child.update_agent_state(state)
+                    break
 
     def update_all_git_statuses(self, statuses: dict[str, GitStatus]) -> None:
         """Bulk update git status on all items."""

--- a/tests/test_agent_providers.py
+++ b/tests/test_agent_providers.py
@@ -221,6 +221,71 @@ class TestBuildCommandResume:
         assert "--resume" not in script
 
 
+class TestBuildCommandSystemPrompt:
+    def test_claude_uses_append_system_prompt_flag(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command(
+                "/tmp/wt", system_prompt="You are the orchestrator."
+            )
+        )[2]
+        assert "--append-system-prompt" in script
+        assert "You are the orchestrator." in script
+
+    def test_claude_no_system_prompt_no_flag(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command("/tmp/wt")
+        )[2]
+        assert "--append-system-prompt" not in script
+
+    def test_claude_none_system_prompt_no_flag(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command("/tmp/wt", system_prompt=None)
+        )[2]
+        assert "--append-system-prompt" not in script
+
+    def test_codex_prepends_system_prompt_to_instruction(self):
+        script = shlex.split(
+            get_agent_provider("codex").build_command(
+                "/tmp/wt",
+                instruction="do stuff",
+                system_prompt="You are the orchestrator.",
+            )
+        )[2]
+        # Codex has no system_prompt_flag, so prompt is prepended to instruction
+        assert "--append-system-prompt" not in script
+        assert "You are the orchestrator." in script
+        assert "do stuff" in script
+
+    def test_codex_system_prompt_without_instruction(self):
+        script = shlex.split(
+            get_agent_provider("codex").build_command(
+                "/tmp/wt", system_prompt="You are the orchestrator."
+            )
+        )[2]
+        assert "You are the orchestrator." in script
+
+    def test_gemini_prepends_system_prompt_to_instruction(self):
+        script = shlex.split(
+            get_agent_provider("gemini").build_command(
+                "/tmp/wt",
+                instruction="hello",
+                system_prompt="You are the orchestrator.",
+            )
+        )[2]
+        assert "-i" in script
+        assert "You are the orchestrator." in script
+        assert "hello" in script
+
+    def test_gemini_system_prompt_without_instruction(self):
+        script = shlex.split(
+            get_agent_provider("gemini").build_command(
+                "/tmp/wt", system_prompt="You are the orchestrator."
+            )
+        )[2]
+        assert "-i" in script
+        assert "You are the orchestrator." in script
+
+
 class TestBuildCommandInstruction:
     def test_claude_instruction_as_positional_arg(self):
         script = shlex.split(

--- a/tests/test_agent_providers.py
+++ b/tests/test_agent_providers.py
@@ -190,3 +190,77 @@ class TestBuildCommandResume:
             get_agent_provider("gemini").build_command("/tmp/wt", resume_mode=ResumeMode.NEW)
         )[2]
         assert "--resume" not in script
+
+
+class TestBuildCommandInstruction:
+    def test_claude_instruction_as_positional_arg(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command("/tmp/wt", instruction="do stuff")
+        )[2]
+        exec_part = script.split("exec ")[1]
+        assert "'do stuff'" in exec_part or "do stuff" in exec_part
+
+    def test_codex_instruction_as_positional_arg(self):
+        script = shlex.split(
+            get_agent_provider("codex").build_command("/tmp/wt", instruction="fix bug")
+        )[2]
+        exec_part = script.split("exec ")[1]
+        assert "'fix bug'" in exec_part or "fix bug" in exec_part
+
+    def test_gemini_instruction_via_flag(self):
+        script = shlex.split(
+            get_agent_provider("gemini").build_command("/tmp/wt", instruction="hello")
+        )[2]
+        exec_part = script.split("exec ")[1]
+        assert "-i" in exec_part
+        assert "hello" in exec_part
+
+    def test_no_instruction_when_none(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command("/tmp/wt", instruction=None)
+        )[2]
+        exec_part = script.split("exec ")[1]
+        # Should only have claude + settings, no extra positional
+        parts = shlex.split(exec_part)
+        assert parts[0] == "claude"
+        # No stray positional args (only --settings and its value)
+        non_flag_parts = [p for p in parts[1:] if not p.startswith("--") and "settings" not in parts[parts.index(p) - 1]]
+        assert len(non_flag_parts) == 0
+
+    def test_no_instruction_when_empty_string(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command("/tmp/wt", instruction="")
+        )[2]
+        exec_part = script.split("exec ")[1]
+        parts = shlex.split(exec_part)
+        assert parts[0] == "claude"
+        non_flag_parts = [p for p in parts[1:] if not p.startswith("--") and "settings" not in parts[parts.index(p) - 1]]
+        assert len(non_flag_parts) == 0
+
+    def test_instruction_with_special_chars_is_escaped(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command(
+                "/tmp/wt", instruction="hello 'world' && rm -rf /"
+            )
+        )[2]
+        # The instruction must survive shell escaping — it should appear quoted
+        assert "hello" in script
+        assert "rm -rf" in script
+
+    def test_instruction_combined_with_resume(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command(
+                "/tmp/wt", resume_mode=ResumeMode.RESUME_LAST, instruction="continue task"
+            )
+        )[2]
+        assert "--continue" in script
+        assert "continue task" in script
+
+    def test_instruction_combined_with_skip_permissions(self):
+        script = shlex.split(
+            get_agent_provider("claude").build_command(
+                "/tmp/wt", skip_permissions=True, instruction="deploy now"
+            )
+        )[2]
+        assert "--dangerously-skip-permissions" in script
+        assert "deploy now" in script

--- a/tests/test_agent_providers.py
+++ b/tests/test_agent_providers.py
@@ -220,12 +220,11 @@ class TestBuildCommandInstruction:
             get_agent_provider("claude").build_command("/tmp/wt", instruction=None)
         )[2]
         exec_part = script.split("exec ")[1]
-        # Should only have claude + settings, no extra positional
+        # Should only have claude + --settings <path>
         parts = shlex.split(exec_part)
         assert parts[0] == "claude"
-        # No stray positional args (only --settings and its value)
-        non_flag_parts = [p for p in parts[1:] if not p.startswith("--") and "settings" not in parts[parts.index(p) - 1]]
-        assert len(non_flag_parts) == 0
+        assert parts[1] == "--settings"
+        assert len(parts) == 3
 
     def test_no_instruction_when_empty_string(self):
         script = shlex.split(
@@ -234,8 +233,8 @@ class TestBuildCommandInstruction:
         exec_part = script.split("exec ")[1]
         parts = shlex.split(exec_part)
         assert parts[0] == "claude"
-        non_flag_parts = [p for p in parts[1:] if not p.startswith("--") and "settings" not in parts[parts.index(p) - 1]]
-        assert len(non_flag_parts) == 0
+        assert parts[1] == "--settings"
+        assert len(parts) == 3
 
     def test_instruction_with_special_chars_is_escaped(self):
         script = shlex.split(

--- a/tests/test_agent_providers.py
+++ b/tests/test_agent_providers.py
@@ -121,6 +121,35 @@ class TestClaudeHooksSettings:
         assert context.metadata["settings_path"] in script
 
 
+class TestClaudeMcpSettings:
+    def test_settings_file_with_mcp_server(self):
+        provider = get_agent_provider("claude")
+        context = provider.build_runtime_context("/tmp/wt", socket_path="/tmp/test.sock")
+
+        settings_path = context.metadata["settings_path"]
+        settings = json.loads(open(settings_path, encoding="utf-8").read())
+
+        # Both hooks and mcpServers should be present
+        assert "hooks" in settings
+        assert "mcpServers" in settings
+
+        mcp_cfg = settings["mcpServers"]["lazyagent"]
+        assert mcp_cfg["command"] == "python3"
+        assert mcp_cfg["args"] == ["-m", "lazyagent.mcp_server"]
+        assert mcp_cfg["env"]["LAZYAGENT_SOCKET"] == "/tmp/test.sock"
+        assert mcp_cfg["env"]["PYTHONUNBUFFERED"] == "1"
+
+    def test_settings_file_without_socket_path_has_no_mcp(self):
+        provider = get_agent_provider("claude")
+        context = provider.build_runtime_context("/tmp/wt")
+
+        settings_path = context.metadata["settings_path"]
+        settings = json.loads(open(settings_path, encoding="utf-8").read())
+
+        assert list(settings.keys()) == ["hooks"]
+        assert "mcpServers" not in settings
+
+
 class TestBuildCommandResume:
     def test_claude_new_has_no_resume_flags(self):
         script = shlex.split(

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -94,7 +94,8 @@ def _select_worktree(app: LazyAgent, index: int) -> WorktreeInfo:
         for child in worktree_list.children
         if isinstance(child, WorktreeListItem)
     ][index]
-    worktree_list.index = index
+    # +1 to account for the OrchestratorListItem at position 0
+    worktree_list.index = index + 1
     app.on_list_view_highlighted(WorktreeList.Highlighted(worktree_list, item))
     return item.worktree
 

--- a/tests/test_center_panel.py
+++ b/tests/test_center_panel.py
@@ -11,12 +11,14 @@ def _build_spawn_command(
     skip_permissions: bool = False,
     agent_provider: str = "claude",
     resume_mode: ResumeMode = ResumeMode.NEW,
+    instruction: str = "",
 ) -> str:
     """Reproduce the command-building logic from WorktreePanel.spawn_agent."""
     return get_agent_provider(agent_provider).build_command(
         worktree_path,
         skip_permissions=skip_permissions,
         resume_mode=resume_mode,
+        instruction=instruction or None,
     )
 
 
@@ -99,6 +101,35 @@ class TestCommandBuilding:
         assert "--approval-mode=yolo" in script
         assert "--append-system-prompt" not in script
         assert "--yolo" not in script
+
+
+class TestCommandBuildingWithInstruction:
+    def test_instruction_appears_in_claude_command(self):
+        cmd = _build_spawn_command("/tmp/wt", instruction="fix the bug")
+        script = shlex.split(cmd)[2]
+        assert "fix the bug" in script
+
+    def test_instruction_appears_in_gemini_command_with_flag(self):
+        cmd = _build_spawn_command("/tmp/wt", agent_provider="gemini", instruction="hello")
+        script = shlex.split(cmd)[2]
+        exec_part = script.split("exec ")[1]
+        assert "-i" in exec_part
+        assert "hello" in exec_part
+
+    def test_empty_instruction_not_in_command(self):
+        cmd = _build_spawn_command("/tmp/wt", instruction="")
+        script = shlex.split(cmd)[2]
+        exec_part = script.split("exec ")[1]
+        # Only claude + settings flag args
+        parts = shlex.split(exec_part)
+        assert parts[0] == "claude"
+        assert "-i" not in parts
+
+    def test_instruction_with_skip_permissions(self):
+        cmd = _build_spawn_command("/tmp/wt", skip_permissions=True, instruction="deploy")
+        script = shlex.split(cmd)[2]
+        assert "--dangerously-skip-permissions" in script
+        assert "deploy" in script
 
 
 class TestEnvExports:

--- a/tests/test_center_panel.py
+++ b/tests/test_center_panel.py
@@ -11,14 +11,12 @@ def _build_spawn_command(
     skip_permissions: bool = False,
     agent_provider: str = "claude",
     resume_mode: ResumeMode = ResumeMode.NEW,
-    instruction: str = "",
 ) -> str:
     """Reproduce the command-building logic from WorktreePanel.spawn_agent."""
     return get_agent_provider(agent_provider).build_command(
         worktree_path,
         skip_permissions=skip_permissions,
         resume_mode=resume_mode,
-        instruction=instruction or None,
     )
 
 
@@ -101,35 +99,6 @@ class TestCommandBuilding:
         assert "--approval-mode=yolo" in script
         assert "--append-system-prompt" not in script
         assert "--yolo" not in script
-
-
-class TestCommandBuildingWithInstruction:
-    def test_instruction_appears_in_claude_command(self):
-        cmd = _build_spawn_command("/tmp/wt", instruction="fix the bug")
-        script = shlex.split(cmd)[2]
-        assert "fix the bug" in script
-
-    def test_instruction_appears_in_gemini_command_with_flag(self):
-        cmd = _build_spawn_command("/tmp/wt", agent_provider="gemini", instruction="hello")
-        script = shlex.split(cmd)[2]
-        exec_part = script.split("exec ")[1]
-        assert "-i" in exec_part
-        assert "hello" in exec_part
-
-    def test_empty_instruction_not_in_command(self):
-        cmd = _build_spawn_command("/tmp/wt", instruction="")
-        script = shlex.split(cmd)[2]
-        exec_part = script.split("exec ")[1]
-        # Only claude + settings flag args
-        parts = shlex.split(exec_part)
-        assert parts[0] == "claude"
-        assert "-i" not in parts
-
-    def test_instruction_with_skip_permissions(self):
-        cmd = _build_spawn_command("/tmp/wt", skip_permissions=True, instruction="deploy")
-        script = shlex.split(cmd)[2]
-        assert "--dangerously-skip-permissions" in script
-        assert "deploy" in script
 
 
 class TestEnvExports:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from lazyagent.config import Config, WorktreeConfig, format_command, load_config
+from lazyagent.config import Config, OrchestratorConfig, WorktreeConfig, format_command, load_config
 
 
 class TestLoadConfig:
@@ -78,6 +78,39 @@ provider = "other"
         (tmp_path / ".lazyagent.toml").write_text("[worktree]\n")
         config = load_config(tmp_path)
         assert config.default_branch == "master"
+
+    def test_orchestrator_defaults(self, tmp_path: Path):
+        config = load_config(tmp_path)
+        assert config.orchestrator.prompt_file is None
+        assert config.orchestrator.agent_instruction_template is None
+
+    def test_orchestrator_prompt_file(self, tmp_path: Path):
+        toml_content = """\
+[orchestrator]
+prompt_file = "my-prompt.md"
+"""
+        (tmp_path / ".lazyagent.toml").write_text(toml_content)
+        config = load_config(tmp_path)
+        assert config.orchestrator.prompt_file == "my-prompt.md"
+
+    def test_orchestrator_agent_instruction_template(self, tmp_path: Path):
+        toml_content = """\
+[orchestrator]
+agent_instruction_template = "/clickup-fix-card {task_id}"
+"""
+        (tmp_path / ".lazyagent.toml").write_text(toml_content)
+        config = load_config(tmp_path)
+        assert config.orchestrator.agent_instruction_template == "/clickup-fix-card {task_id}"
+
+    def test_orchestrator_partial_config(self, tmp_path: Path):
+        toml_content = """\
+[orchestrator]
+prompt_file = "custom.md"
+"""
+        (tmp_path / ".lazyagent.toml").write_text(toml_content)
+        config = load_config(tmp_path)
+        assert config.orchestrator.prompt_file == "custom.md"
+        assert config.orchestrator.agent_instruction_template is None
 
 
 class TestConfigProperties:

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -1,0 +1,248 @@
+"""Tests for the IPC server handlers."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lazyagent.ipc import IpcServer, _ok, _err
+from lazyagent.models import AgentState, AgentStatus, GitStatus, LifecycleConfidence, WorktreeInfo
+from lazyagent.worktree_manager import WorktreeManagerError
+
+
+def _make_app(worktrees=None, agent_states=None, git_statuses=None):
+    """Create a mock LazyAgent app."""
+    app = MagicMock()
+    app.worktrees = worktrees or []
+    app._agent_states = agent_states or {}
+    app._git_statuses = git_statuses or {}
+    app._repo_root = "/tmp/repo"
+    app._config.agent.provider = "claude"
+    app._get_agent_state = MagicMock(side_effect=lambda p: app._agent_states.setdefault(p, AgentState()))
+    return app
+
+
+def _make_worktree(path="/tmp/repo", branch="main", is_main=True):
+    return WorktreeInfo(path=path, head="abc123", branch=branch, is_main=is_main, is_bare=False)
+
+
+class TestListWorktrees:
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_no_worktrees(self):
+        app = _make_app()
+        server = IpcServer(app, "/tmp/test.sock")
+        result = await server._dispatch("req-1", "list_worktrees", {})
+        assert result == _ok("req-1", [])
+
+    @pytest.mark.asyncio
+    async def test_returns_worktrees_with_status(self):
+        wt = _make_worktree("/tmp/repo", "main", is_main=True)
+        wt2 = _make_worktree("/tmp/repo-feat", "feat", is_main=False)
+        state = AgentState(status=AgentStatus.RUNNING)
+        git_st = GitStatus(dirty_count=2, ahead=1)
+
+        app = _make_app(
+            worktrees=[wt, wt2],
+            agent_states={"/tmp/repo-feat": state},
+            git_statuses={"/tmp/repo": git_st},
+        )
+        server = IpcServer(app, "/tmp/test.sock")
+        result = await server._dispatch("req-2", "list_worktrees", {})
+
+        data = result["result"]
+        assert len(data) == 2
+
+        # Main worktree
+        assert data[0]["path"] == "/tmp/repo"
+        assert data[0]["is_main"] is True
+        assert data[0]["agent_status"] == "no_agent"
+        assert data[0]["git_status"]["dirty_count"] == 2
+
+        # Feature worktree
+        assert data[1]["path"] == "/tmp/repo-feat"
+        assert data[1]["agent_status"] == "running"
+
+
+class TestCreateWorktree:
+    @pytest.mark.asyncio
+    async def test_rejects_empty_branch(self):
+        app = _make_app()
+        server = IpcServer(app, "/tmp/test.sock")
+        result = await server._dispatch("req-1", "create_worktree", {"branch": ""})
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_creates_worktree(self):
+        app = _make_app()
+        server = IpcServer(app, "/tmp/test.sock")
+
+        with patch("lazyagent.ipc.WorktreeManager") as MockWM:
+            instance = MockWM.return_value
+            instance.create.return_value = "/tmp/repo-feat"
+
+            result = await server._dispatch("req-1", "create_worktree", {
+                "branch": "feat",
+                "base_branch": "main",
+            })
+
+        assert result == _ok("req-1", {"path": "/tmp/repo-feat", "branch": "feat"})
+        instance.create.assert_called_once_with("feat", "main")
+        app.call_later.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_propagates_worktree_manager_error(self):
+        app = _make_app()
+        server = IpcServer(app, "/tmp/test.sock")
+
+        with patch("lazyagent.ipc.WorktreeManager") as MockWM:
+            instance = MockWM.return_value
+            instance.create.side_effect = WorktreeManagerError("branch exists")
+
+            result = await server._dispatch("req-1", "create_worktree", {"branch": "feat"})
+
+        assert "error" in result
+        assert result["error"]["code"] == "WORKTREE_ERROR"
+
+
+class TestRemoveWorktree:
+    @pytest.mark.asyncio
+    async def test_rejects_main_worktree(self):
+        wt = _make_worktree("/tmp/repo", "main", is_main=True)
+        app = _make_app(worktrees=[wt])
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch("req-1", "remove_worktree", {"worktree_path": "/tmp/repo"})
+        assert "error" in result
+        assert "main worktree" in result["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_worktree_with_running_agent(self):
+        wt = _make_worktree("/tmp/repo-feat", "feat", is_main=False)
+        state = AgentState(status=AgentStatus.RUNNING)
+        app = _make_app(worktrees=[wt], agent_states={"/tmp/repo-feat": state})
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch("req-1", "remove_worktree", {"worktree_path": "/tmp/repo-feat"})
+        assert "error" in result
+        assert "running" in result["error"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_worktree(self):
+        app = _make_app()
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch("req-1", "remove_worktree", {"worktree_path": "/tmp/unknown"})
+        assert "error" in result
+        assert "Unknown worktree" in result["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_removes_worktree(self):
+        wt = _make_worktree("/tmp/repo-feat", "feat", is_main=False)
+        app = _make_app(worktrees=[wt])
+        server = IpcServer(app, "/tmp/test.sock")
+
+        with patch("lazyagent.ipc.WorktreeManager") as MockWM:
+            instance = MockWM.return_value
+
+            result = await server._dispatch("req-1", "remove_worktree", {
+                "worktree_path": "/tmp/repo-feat",
+                "force": True,
+            })
+
+        assert result == _ok("req-1", {"removed": "/tmp/repo-feat"})
+        instance.remove.assert_called_once_with("/tmp/repo-feat", True)
+
+
+class TestSpawnAgent:
+    @pytest.mark.asyncio
+    async def test_rejects_empty_worktree_path(self):
+        app = _make_app()
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch("req-1", "spawn_agent", {"worktree_path": ""})
+        assert "error" in result
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_worktree(self):
+        app = _make_app()
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch("req-1", "spawn_agent", {"worktree_path": "/tmp/unknown"})
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_rejects_duplicate_spawn(self):
+        wt = _make_worktree("/tmp/repo-feat", "feat", is_main=False)
+        state = AgentState(status=AgentStatus.RUNNING)
+        app = _make_app(worktrees=[wt], agent_states={"/tmp/repo-feat": state})
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch("req-1", "spawn_agent", {"worktree_path": "/tmp/repo-feat"})
+        assert "error" in result
+        assert "already running" in result["error"]["message"]
+
+
+class TestGetAgentStatus:
+    @pytest.mark.asyncio
+    async def test_returns_no_agent_when_not_tracked(self):
+        app = _make_app()
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch("req-1", "get_agent_status", {"worktree_path": "/tmp/repo"})
+        assert result["result"]["status"] == "no_agent"
+
+    @pytest.mark.asyncio
+    async def test_returns_current_status(self):
+        state = AgentState(
+            status=AgentStatus.WAITING_FOR_USER,
+            confidence=LifecycleConfidence.HIGH,
+            detail="needs input",
+        )
+        app = _make_app(agent_states={"/tmp/repo": state})
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch("req-1", "get_agent_status", {"worktree_path": "/tmp/repo"})
+        assert result["result"]["status"] == "waiting_for_user"
+        assert result["result"]["confidence"] == "high"
+        assert result["result"]["detail"] == "needs input"
+
+
+class TestReadAgentOutput:
+    @pytest.mark.asyncio
+    async def test_rejects_missing_terminal(self):
+        app = _make_app()
+        server = IpcServer(app, "/tmp/test.sock")
+
+        # Mock query_one to return a CenterPanel mock that returns no panel
+        mock_center = MagicMock()
+        mock_center.get_panel.return_value = None
+        app.query_one.return_value = mock_center
+
+        result = await server._dispatch("req-1", "read_agent_output", {"worktree_path": "/tmp/repo"})
+        assert "error" in result
+
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_unknown_method_returns_error(self):
+        app = _make_app()
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch("req-1", "nonexistent", {})
+        assert "error" in result
+        assert result["error"]["code"] == "UNKNOWN_METHOD"
+
+
+class TestHelpers:
+    def test_ok_format(self):
+        assert _ok("id-1", {"key": "val"}) == {"id": "id-1", "result": {"key": "val"}}
+
+    def test_err_format(self):
+        assert _err("id-1", "CODE", "msg") == {
+            "id": "id-1",
+            "error": {"code": "CODE", "message": "msg"},
+        }

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,134 @@
+"""Tests for the MCP server IpcClient."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from lazyagent.mcp_server import IpcClient, _get_client
+
+
+class TestIpcClient:
+    @pytest.mark.asyncio
+    async def test_call_sends_correct_json_and_returns_result(self, tmp_path):
+        """Start a fake Unix socket server and verify IpcClient sends correct format."""
+        socket_path = str(tmp_path / "test.sock")
+        received_requests: list[dict] = []
+
+        async def handle_client(reader, writer):
+            line = await reader.readline()
+            request = json.loads(line)
+            received_requests.append(request)
+            response = {"id": request["id"], "result": [{"path": "/tmp/wt"}]}
+            writer.write(json.dumps(response).encode() + b"\n")
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+
+        server = await asyncio.start_unix_server(handle_client, path=socket_path)
+
+        try:
+            client = IpcClient(socket_path)
+            result = await client.call("list_worktrees", {"foo": "bar"})
+
+            assert result == [{"path": "/tmp/wt"}]
+            assert len(received_requests) == 1
+
+            req = received_requests[0]
+            assert req["method"] == "list_worktrees"
+            assert req["params"] == {"foo": "bar"}
+            assert "id" in req
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    @pytest.mark.asyncio
+    async def test_call_raises_on_error_response(self, tmp_path):
+        socket_path = str(tmp_path / "test.sock")
+
+        async def handle_client(reader, writer):
+            line = await reader.readline()
+            request = json.loads(line)
+            response = {
+                "id": request["id"],
+                "error": {"code": "VALIDATION_ERROR", "message": "bad input"},
+            }
+            writer.write(json.dumps(response).encode() + b"\n")
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+
+        server = await asyncio.start_unix_server(handle_client, path=socket_path)
+
+        try:
+            client = IpcClient(socket_path)
+            with pytest.raises(RuntimeError, match="VALIDATION_ERROR.*bad input"):
+                await client.call("create_worktree", {"branch": ""})
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    @pytest.mark.asyncio
+    async def test_call_raises_on_closed_connection(self, tmp_path):
+        socket_path = str(tmp_path / "test.sock")
+
+        async def handle_client(reader, writer):
+            # Close immediately without responding
+            writer.close()
+            await writer.wait_closed()
+
+        server = await asyncio.start_unix_server(handle_client, path=socket_path)
+
+        try:
+            client = IpcClient(socket_path)
+            with pytest.raises(ConnectionError):
+                await client.call("list_worktrees")
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    @pytest.mark.asyncio
+    async def test_call_with_no_params(self, tmp_path):
+        """Calling with no params sends empty dict."""
+        socket_path = str(tmp_path / "test.sock")
+        received_requests: list[dict] = []
+
+        async def handle_client(reader, writer):
+            line = await reader.readline()
+            request = json.loads(line)
+            received_requests.append(request)
+            response = {"id": request["id"], "result": []}
+            writer.write(json.dumps(response).encode() + b"\n")
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+
+        server = await asyncio.start_unix_server(handle_client, path=socket_path)
+
+        try:
+            client = IpcClient(socket_path)
+            await client.call("list_worktrees")
+            assert received_requests[0]["params"] == {}
+        finally:
+            server.close()
+            await server.wait_closed()
+
+
+class TestGetClient:
+    def test_raises_when_env_not_set(self):
+        with patch.dict(os.environ, {}, clear=True):
+            # Ensure LAZYAGENT_SOCKET is not set
+            os.environ.pop("LAZYAGENT_SOCKET", None)
+            with pytest.raises(RuntimeError, match="LAZYAGENT_SOCKET"):
+                _get_client()
+
+    def test_returns_client_when_env_set(self):
+        with patch.dict(os.environ, {"LAZYAGENT_SOCKET": "/tmp/test.sock"}):
+            client = _get_client()
+            assert isinstance(client, IpcClient)
+            assert client._socket_path == "/tmp/test.sock"

--- a/tests/test_orchestrator_panel.py
+++ b/tests/test_orchestrator_panel.py
@@ -222,7 +222,7 @@ async def test_orchestrator_status_changed_updates_sidebar(monkeypatch):
         app.on_agent_status_changed(event)
         await pilot.pause()
 
-        assert app._orchestrator_state.status == AgentStatus.RUNNING
+        assert app._get_agent_state(ORCHESTRATOR_KEY).status == AgentStatus.RUNNING
 
         # Verify sidebar was updated
         wt_list = app.query_one(WorktreeList)
@@ -240,14 +240,14 @@ async def test_orchestrator_exited_resets_state(monkeypatch):
         from lazyagent.messages import AgentExited
 
         # Set running state first
-        app._orchestrator_state.status = AgentStatus.RUNNING
+        app._get_agent_state(ORCHESTRATOR_KEY).status = AgentStatus.RUNNING
 
         app.notify = MagicMock()
         event = AgentExited(worktree_path=ORCHESTRATOR_KEY)
         await app.on_agent_exited(event)
         await pilot.pause()
 
-        assert app._orchestrator_state.status == AgentStatus.NO_AGENT
+        assert app._get_agent_state(ORCHESTRATOR_KEY).status == AgentStatus.NO_AGENT
         app.notify.assert_called_once()
         assert "Orchestrator exited" in app.notify.call_args.args[0]
 

--- a/tests/test_orchestrator_panel.py
+++ b/tests/test_orchestrator_panel.py
@@ -1,0 +1,271 @@
+"""Tests for orchestrator panel UI integration."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from lazyagent.app import LazyAgent
+from lazyagent.config import Config
+from lazyagent.models import AgentState, AgentStatus, GitStatus, LifecycleConfidence, WorktreeInfo
+from lazyagent.widgets.center_panel import CenterPanel
+from lazyagent.widgets.orchestrator_panel import ORCHESTRATOR_KEY, OrchestratorPanel
+from lazyagent.widgets.worktree_list import OrchestratorListItem, WorktreeList, WorktreeListItem
+from lazyagent.widgets.center_panel import WorktreePanel
+
+
+MAIN_WORKTREE = WorktreeInfo(
+    path="/repo",
+    head="a" * 40,
+    branch="main",
+    is_main=True,
+    is_bare=False,
+)
+
+FEATURE_WORKTREE = WorktreeInfo(
+    path="/repo-feature",
+    head="b" * 40,
+    branch="feature/demo",
+    is_main=False,
+    is_bare=False,
+)
+
+WORKTREES = [MAIN_WORKTREE, FEATURE_WORKTREE]
+
+
+class DummyWorktreeManager:
+    def __init__(self, repo_path):
+        self.repo_path = Path(repo_path)
+
+    def list(self):
+        return WORKTREES
+
+    def get_all_git_statuses(self, worktrees):
+        return {wt.path: GitStatus() for wt in worktrees}
+
+    @staticmethod
+    def get_diff(worktree_path):
+        return ""
+
+    @staticmethod
+    def is_gh_available():
+        return False
+
+
+def _patch_app(monkeypatch):
+    monkeypatch.setattr("lazyagent.app.WorktreeManager", DummyWorktreeManager)
+    monkeypatch.setattr("lazyagent.app.load_config", lambda repo_root: Config())
+    monkeypatch.setattr(WorktreePanel, "_try_start_terminal", lambda self: None)
+    monkeypatch.setattr(LazyAgent, "_refresh_pr_status", lambda self: None)
+
+
+# --- OrchestratorListItem unit tests ---
+
+
+class TestOrchestratorListItem:
+    def test_default_status_shows_dashes(self):
+        item = OrchestratorListItem()
+        label = item._build_label()
+        assert "ORCH" in label
+        assert "---" in label
+
+    def test_running_status_shows_running(self):
+        state = AgentState(status=AgentStatus.RUNNING, confidence=LifecycleConfidence.HIGH)
+        item = OrchestratorListItem(agent_state=state)
+        label = item._build_label()
+        assert "running" in label
+
+    def test_update_agent_state_changes_label(self):
+        item = OrchestratorListItem()
+        assert "---" in item._build_label()
+        item.update_agent_state(
+            AgentState(status=AgentStatus.WAITING, confidence=LifecycleConfidence.HIGH)
+        )
+        assert "waiting" in item._build_label()
+
+
+# --- WorktreeList orchestrator prepend (tested via app integration below) ---
+
+
+# --- CenterPanel orchestrator methods ---
+
+
+class TestCenterPanelOrchestrator:
+    def test_ensure_orchestrator_panel_creates_panel(self):
+        center = CenterPanel()
+        assert center.get_orchestrator_panel() is None
+        # Can't fully test compose without running app, but verify _panels tracking
+        assert ORCHESTRATOR_KEY not in center._panels
+
+    def test_panel_key_is_deterministic(self):
+        """The orchestrator panel ID is always 'wp-orchestrator'."""
+        center = CenterPanel()
+        # Verify constant
+        assert ORCHESTRATOR_KEY == "__orchestrator__"
+
+
+# --- App integration tests ---
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_is_first_sidebar_entry(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        wt_list = app.query_one(WorktreeList)
+        children = [c for c in wt_list.children if isinstance(c, (OrchestratorListItem, WorktreeListItem))]
+        assert len(children) == 3
+        assert isinstance(children[0], OrchestratorListItem)
+
+
+@pytest.mark.asyncio
+async def test_selecting_orchestrator_switches_to_orchestrator_panel(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        wt_list = app.query_one(WorktreeList)
+        # Select orchestrator (index 0)
+        orch_item = list(wt_list.children)[0]
+        wt_list.index = 0
+        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await pilot.pause()
+
+        assert app._orchestrator_selected is True
+        assert app._selected_worktree is None
+
+        center = app.query_one(CenterPanel)
+        panel = center.get_orchestrator_panel()
+        assert panel is not None
+        assert isinstance(panel, OrchestratorPanel)
+
+
+@pytest.mark.asyncio
+async def test_selecting_worktree_after_orchestrator_clears_flag(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        wt_list = app.query_one(WorktreeList)
+
+        # Select orchestrator
+        orch_item = list(wt_list.children)[0]
+        wt_list.index = 0
+        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await pilot.pause()
+        assert app._orchestrator_selected is True
+
+        # Select worktree
+        wt_item = list(wt_list.children)[1]
+        wt_list.index = 1
+        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, wt_item))
+        await pilot.pause()
+        assert app._orchestrator_selected is False
+        assert app._selected_worktree is not None
+
+
+@pytest.mark.asyncio
+async def test_spawn_on_orchestrator_shows_modal(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        wt_list = app.query_one(WorktreeList)
+
+        # Select orchestrator
+        orch_item = list(wt_list.children)[0]
+        wt_list.index = 0
+        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await pilot.pause()
+
+        # Mock push_screen to verify modal is shown
+        app.push_screen = MagicMock()
+        app.action_spawn_agent()
+        app.push_screen.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_on_orchestrator_without_agent_notifies(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        wt_list = app.query_one(WorktreeList)
+
+        # Select orchestrator
+        orch_item = list(wt_list.children)[0]
+        wt_list.index = 0
+        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await pilot.pause()
+
+        app.notify = MagicMock()
+        await app.action_stop_agent()
+        app.notify.assert_called_once()
+        assert "No running orchestrator" in app.notify.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_status_changed_updates_sidebar(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        from lazyagent.messages import AgentStatusChanged
+
+        event = AgentStatusChanged(
+            worktree_path=ORCHESTRATOR_KEY,
+            status=AgentStatus.RUNNING,
+            confidence=LifecycleConfidence.HIGH,
+        )
+        app.on_agent_status_changed(event)
+        await pilot.pause()
+
+        assert app._orchestrator_state.status == AgentStatus.RUNNING
+
+        # Verify sidebar was updated
+        wt_list = app.query_one(WorktreeList)
+        orch_item = list(wt_list.children)[0]
+        assert isinstance(orch_item, OrchestratorListItem)
+        assert orch_item._agent_state.status == AgentStatus.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_exited_resets_state(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        from lazyagent.messages import AgentExited
+
+        # Set running state first
+        app._orchestrator_state.status = AgentStatus.RUNNING
+
+        app.notify = MagicMock()
+        event = AgentExited(worktree_path=ORCHESTRATOR_KEY)
+        await app.on_agent_exited(event)
+        await pilot.pause()
+
+        assert app._orchestrator_state.status == AgentStatus.NO_AGENT
+        app.notify.assert_called_once()
+        assert "Orchestrator exited" in app.notify.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_ctrl_j_on_orchestrator_triggers_spawn_when_no_agent(monkeypatch):
+    _patch_app(monkeypatch)
+    app = LazyAgent(repo_path="/repo")
+
+    async with app.run_test() as pilot:
+        wt_list = app.query_one(WorktreeList)
+
+        # Select orchestrator
+        orch_item = list(wt_list.children)[0]
+        wt_list.index = 0
+        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await pilot.pause()
+
+        app.action_spawn_agent = MagicMock()
+        app.action_focus_agent()
+        app.action_spawn_agent.assert_called_once()

--- a/tests/test_orchestrator_prompt.py
+++ b/tests/test_orchestrator_prompt.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from lazyagent.config import Config, OrchestratorConfig
+from lazyagent.orchestrator_prompt import (
+    DEFAULT_ORCHESTRATOR_PROMPT,
+    DEFAULT_USER_PROMPT_FILE,
+    compose_orchestrator_prompt,
+)
+
+
+class TestDefaultPrompt:
+    def test_contains_identity(self):
+        assert "orchestrator" in DEFAULT_ORCHESTRATOR_PROMPT.lower()
+
+    def test_contains_mcp_tools(self):
+        for tool in [
+            "list_worktrees",
+            "create_worktree",
+            "remove_worktree",
+            "spawn_agent",
+            "stop_agent",
+            "get_agent_status",
+            "read_agent_output",
+        ]:
+            assert tool in DEFAULT_ORCHESTRATOR_PROMPT
+
+    def test_contains_workflow_phases(self):
+        assert "### 1. Assess" in DEFAULT_ORCHESTRATOR_PROMPT
+        assert "### 3. Execute" in DEFAULT_ORCHESTRATOR_PROMPT
+        assert "### 4. Monitor" in DEFAULT_ORCHESTRATOR_PROMPT
+
+
+class TestComposeOrchestratorPrompt:
+    def test_default_only(self, tmp_path: Path):
+        config = Config()
+        result = compose_orchestrator_prompt(config, tmp_path)
+        assert result == DEFAULT_ORCHESTRATOR_PROMPT
+
+    def test_with_user_prompt_file(self, tmp_path: Path):
+        (tmp_path / DEFAULT_USER_PROMPT_FILE).write_text("Custom user rules here.")
+        config = Config()
+        result = compose_orchestrator_prompt(config, tmp_path)
+        assert DEFAULT_ORCHESTRATOR_PROMPT in result
+        assert "Custom user rules here." in result
+
+    def test_with_custom_prompt_file_path(self, tmp_path: Path):
+        (tmp_path / "my-prompt.md").write_text("My custom prompt.")
+        config = Config(
+            orchestrator=OrchestratorConfig(prompt_file="my-prompt.md")
+        )
+        result = compose_orchestrator_prompt(config, tmp_path)
+        assert "My custom prompt." in result
+
+    def test_missing_user_file_returns_default_only(self, tmp_path: Path):
+        config = Config()
+        result = compose_orchestrator_prompt(config, tmp_path)
+        assert result == DEFAULT_ORCHESTRATOR_PROMPT
+
+    def test_with_template(self, tmp_path: Path):
+        config = Config(
+            orchestrator=OrchestratorConfig(
+                agent_instruction_template="/clickup-fix-card {task_id}"
+            )
+        )
+        result = compose_orchestrator_prompt(config, tmp_path)
+        assert "/clickup-fix-card {task_id}" in result
+        assert "Agent instruction template" in result
+
+    def test_with_template_and_user_file(self, tmp_path: Path):
+        (tmp_path / DEFAULT_USER_PROMPT_FILE).write_text("Extra rules.")
+        config = Config(
+            orchestrator=OrchestratorConfig(
+                agent_instruction_template="/fix {id}"
+            )
+        )
+        result = compose_orchestrator_prompt(config, tmp_path)
+        # All three layers present
+        assert DEFAULT_ORCHESTRATOR_PROMPT in result
+        assert "/fix {id}" in result
+        assert "Extra rules." in result
+        # Template appears before user prompt
+        assert result.index("/fix {id}") < result.index("Extra rules.")
+
+    def test_empty_user_file_ignored(self, tmp_path: Path):
+        (tmp_path / DEFAULT_USER_PROMPT_FILE).write_text("   \n  ")
+        config = Config()
+        result = compose_orchestrator_prompt(config, tmp_path)
+        assert result == DEFAULT_ORCHESTRATOR_PROMPT

--- a/uv.lock
+++ b/uv.lock
@@ -158,6 +158,29 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -185,6 +208,97 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -203,6 +317,66 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+    { url = "https://files.pythonhosted.org/packages/63/0c/dca8abb64e7ca4f6b2978769f6fea5ad06686a190cec381f0a796fdcaaba/cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f", size = 3476879, upload-time = "2026-04-08T01:57:38.664Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ea/075aac6a84b7c271578d81a2f9968acb6e273002408729f2ddff517fed4a/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15", size = 4219700, upload-time = "2026-04-08T01:57:40.625Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/7b/1c55db7242b5e5612b29fc7a630e91ee7a6e3c8e7bf5406d22e206875fbd/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455", size = 4385982, upload-time = "2026-04-08T01:57:42.725Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
 ]
 
 [[package]]
@@ -339,6 +513,52 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -369,10 +589,38 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "lazyagent"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "mcp" },
     { name = "pyte" },
     { name = "textual" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -387,6 +635,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "mcp", specifier = ">=1.0.0" },
     { name = "pyte", specifier = ">=0.8.0" },
     { name = "textual", specifier = ">=8.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
@@ -511,6 +760,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
 ]
 
 [[package]]
@@ -875,12 +1149,185 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b6/338abf60225acc18cdc08b4faef592d0310923d19a87fba1faf05af5346e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97", size = 1918815, upload-time = "2025-11-04T13:39:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/2ed0433e682983d8e8cba9c8d8ef274d4791ec6a6f24c58935b90e780e0a/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9", size = 2065567, upload-time = "2025-11-04T13:39:12.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/24/cf84974ee7d6eae06b9e63289b7b8f6549d416b5c199ca2d7ce13bbcf619/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52", size = 2230442, upload-time = "2025-11-04T13:39:13.962Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/21/4e287865504b3edc0136c89c9c09431be326168b1eb7841911cbc877a995/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941", size = 2350956, upload-time = "2025-11-04T13:39:15.889Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/7727ef2ffa4b62fcab916686a68a0426b9b790139720e1934e8ba797e238/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a", size = 2068253, upload-time = "2025-11-04T13:39:17.403Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/a4abfc79604bcb4c748e18975c44f94f756f08fb04218d5cb87eb0d3a63e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c", size = 2177050, upload-time = "2025-11-04T13:39:19.351Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b1/de2e9a9a79b480f9cb0b6e8b6ba4c50b18d4e89852426364c66aa82bb7b3/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2", size = 2147178, upload-time = "2025-11-04T13:39:21Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c1/dfb33f837a47b20417500efaa0378adc6635b3c79e8369ff7a03c494b4ac/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556", size = 2341833, upload-time = "2025-11-04T13:39:22.606Z" },
+    { url = "https://files.pythonhosted.org/packages/47/36/00f398642a0f4b815a9a558c4f1dca1b4020a7d49562807d7bc9ff279a6c/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49", size = 2321156, upload-time = "2025-11-04T13:39:25.843Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/cad3acd89fde2010807354d978725ae111ddf6d0ea46d1ea1775b5c1bd0c/pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba", size = 1989378, upload-time = "2025-11-04T13:39:27.92Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/d338652464c6c367e5608e4488201702cd1cbb0f33f7b6a85a60fe5f3720/pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9", size = 2013622, upload-time = "2025-11-04T13:39:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351, upload-time = "2025-11-04T13:43:02.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363, upload-time = "2025-11-04T13:43:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615, upload-time = "2025-11-04T13:43:08.116Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0a/99a53d06dd0348b2008f2f30884b34719c323f16c3be4e6cc1203b74a91d/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2", size = 2175369, upload-time = "2025-11-04T13:43:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/94/30ca3b73c6d485b9bb0bc66e611cff4a7138ff9736b7e66bcf0852151636/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093", size = 2144218, upload-time = "2025-11-04T13:43:15.431Z" },
+    { url = "https://files.pythonhosted.org/packages/87/57/31b4f8e12680b739a91f472b5671294236b82586889ef764b5fbc6669238/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a", size = 2329951, upload-time = "2025-11-04T13:43:18.062Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/73/3c2c8edef77b8f7310e6fb012dbc4b8551386ed575b9eb6fb2506e28a7eb/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963", size = 2318428, upload-time = "2025-11-04T13:43:20.679Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/02/8559b1f26ee0d502c74f9cca5c0d2fd97e967e083e006bbbb4e97f3a043a/pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a", size = 2147009, upload-time = "2025-11-04T13:43:23.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -928,6 +1375,60 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/45/e23b5dc14ddb9918ae4a625379506b17b6f8fc56ca1d82db62462f59aea6/python_multipart-0.0.24.tar.gz", hash = "sha256:9574c97e1c026e00bc30340ef7c7d76739512ab4dfd428fec8c330fa6a5cc3c8", size = 37695, upload-time = "2026-04-05T20:49:13.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/73/89930efabd4da63cea44a3f438aeb753d600123570e6d6264e763617a9ce/python_multipart-0.0.24-py3-none-any.whl", hash = "sha256:9b110a98db707df01a53c194f0af075e736a770dc5058089650d70b4a182f950", size = 24420, upload-time = "2026-04-05T20:49:12.555Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
+    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -938,6 +1439,154 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]
@@ -1054,12 +1703,38 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
 name = "uc-micro-py"
 version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/91/7a/146a99696aee0609e3712f2b44c6274566bc368dfe8375191278045186b8/uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a", size = 6043, upload-time = "2024-02-09T16:52:01.654Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5", size = 6229, upload-time = "2024-02-09T16:52:00.371Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add Unix domain socket IPC server and MCP stdio server to expose
lazyagent primitives (worktree CRUD, agent spawn/stop/status, terminal
output reading) as MCP tools for a future orchestrator agent.

- IPC server starts on app mount at /tmp/lazyagent-{pid}/ipc.sock
- MCP server uses FastMCP with 7 tools forwarding to IPC
- socket_path param threaded through agent_providers and center_panel
- MCP injection disabled for now (only future orchestrator will use it)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>Add Unix domain socket IPC server and MCP stdio server to expose
lazyagent primitives (worktree CRUD, agent spawn/stop/status, terminal
output reading) as MCP tools for a future orchestrator agent.

- IPC server starts on app mount at /tmp/lazyagent-{pid}/ipc.sock
- MCP server uses FastMCP with 7 tools forwarding to IPC
- socket_path param threaded through agent_providers and center_panel
- MCP injection disabled for now (only future orchestrator will use it)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>