### PR TITLE
fix: missing MCP tools, IPC socket discovery, and pyte rendering bugs

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "lazyagent": {
       "type": "stdio",
-      "command": ".venv/bin/python3",
-      "args": ["-m", "lazyagent.mcp_server"],
+      "command": "uv",
+      "args": ["run", "--quiet", "python", "-m", "lazyagent.mcp_server"],
       "env": {
         "PYTHONUNBUFFERED": "1"
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,9 @@
 {
   "mcpServers": {
     "lazyagent": {
-      "command": "uv",
-      "args": ["run", "python3", "-m", "lazyagent.mcp_server"],
+      "type": "stdio",
+      "command": ".venv/bin/python3",
+      "args": ["-m", "lazyagent.mcp_server"],
       "env": {
         "PYTHONUNBUFFERED": "1"
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "lazyagent": {
+      "command": "uv",
+      "args": ["run", "python3", "-m", "lazyagent.mcp_server"],
+      "env": {
+        "PYTHONUNBUFFERED": "1"
+      }
+    }
+  }
+}

--- a/src/lazyagent/agent_providers.py
+++ b/src/lazyagent/agent_providers.py
@@ -4,6 +4,7 @@ import json
 import os
 import shlex
 import stat
+import sys
 import tempfile
 from dataclasses import dataclass, field
 from enum import Enum
@@ -258,10 +259,14 @@ def _build_gemini_runtime_context(
         # Point it at a temp directory containing only our MCP entry.
         gemini_home = temp_dir / "gemini_home"
         (gemini_home / ".gemini").mkdir(parents=True, exist_ok=True)
+        # Use sys.executable (the interpreter running lazyagent) rather
+        # than "python3" — for pipx/isolated-venv installs, PATH's
+        # `python3` is the system one and doesn't have lazyagent
+        # installed, so the MCP server would fail to start.
         settings = {
             "mcpServers": {
                 "lazyagent": {
-                    "command": "python3",
+                    "command": sys.executable,
                     "args": ["-m", "lazyagent.mcp_server"],
                     "env": {
                         "PYTHONUNBUFFERED": "1",
@@ -309,9 +314,11 @@ def _build_codex_runtime_context(
         # Point it at a temp directory containing only our MCP entry.
         codex_home = temp_dir / "codex_home"
         codex_home.mkdir(exist_ok=True)
+        # See note in the gemini context builder: sys.executable handles
+        # pipx/isolated-venv installs that "python3" misses.
         config_toml = (
             '[mcp_servers.lazyagent]\n'
-            f'command = "python3"\n'
+            f'command = {json.dumps(sys.executable)}\n'
             f'args = ["-m", "lazyagent.mcp_server"]\n'
             '\n[mcp_servers.lazyagent.env]\n'
             'PYTHONUNBUFFERED = "1"\n'
@@ -365,9 +372,12 @@ def _build_claude_runtime_context(
     }
 
     if socket_path:
+        # sys.executable, not "python3": pipx/isolated-venv installs
+        # don't expose lazyagent on the system python, so a bare "python3"
+        # invocation in the agent's environment would ImportError.
         hooks_settings["mcpServers"] = {
             "lazyagent": {
-                "command": "python3",
+                "command": sys.executable,
                 "args": ["-m", "lazyagent.mcp_server"],
                 "env": {
                     "PYTHONUNBUFFERED": "1",

--- a/src/lazyagent/config.py
+++ b/src/lazyagent/config.py
@@ -112,6 +112,23 @@ def format_command(
     """Expand placeholders and ~ in a command template.
 
     Placeholders: {branch}, {name}, {base}, {path}, {repo}, {force}, {extra}
+
+    **Security note:** the result is sent verbatim to a shell (``bash -c``
+    or pasted into a terminal). Substituted values are NOT shell-quoted —
+    template authors are responsible for placement. In particular:
+
+    - Do NOT embed placeholders inside double quotes; a value containing
+      ``"`` or ``$`` will break the surrounding quoting and can execute
+      arbitrary shell. Single-quote (``'{branch}'``) or use ``{branch}``
+      bare and rely on the value not containing whitespace.
+    - When values can come from an LLM (via the MCP ``extra`` param or
+      a branch name that passed through the orchestrator), prefer
+      template designs that don't depend on quoting at all (e.g. pass
+      values via env vars: ``BRANCH={branch} ./create-worktree.sh``).
+
+    This is intentional: locking values would break templates that already
+    rely on shell expansion (``{path}`` interpolating ``~``, ``{extra}``
+    expanding to multiple flags, etc.).
     """
     expanded = os.path.expanduser(template)
     return expanded.format(

--- a/src/lazyagent/ipc.py
+++ b/src/lazyagent/ipc.py
@@ -20,6 +20,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from lazyagent.agent_providers import ResumeMode
 from lazyagent.models import AgentStatus
 from lazyagent.worktree_manager import WorktreeManager, WorktreeManagerError
 
@@ -55,6 +56,7 @@ class IpcServer:
             "stop_agent": self.handle_stop_agent,
             "get_agent_status": self.handle_get_agent_status,
             "read_agent_output": self.handle_read_agent_output,
+            "send_agent_input": self.handle_send_agent_input,
         }
 
     @property
@@ -169,11 +171,36 @@ class IpcServer:
     async def handle_create_worktree(
         self, request_id: str, params: dict
     ) -> dict:
-        """Create a new worktree. Params: branch, base_branch (optional)."""
+        """Create a new worktree. Params: branch, base_branch (optional), extra (optional)."""
         branch = params.get("branch", "").strip()
         if not branch:
             raise ValueError("branch is required and must not be empty")
         base_branch = params.get("base_branch", "main")
+        extra = params.get("extra", "")
+
+        if self._app._config.has_custom_create:
+            from lazyagent.config import format_command
+
+            repo_root = self._app._repo_root
+            repo_name = os.path.basename(repo_root) if repo_root else ""
+            wt_name = f"{repo_name}-{branch}" if repo_name else branch
+            wt_path = str(
+                os.path.join(os.path.dirname(repo_root), wt_name)
+                if repo_root
+                else wt_name
+            )
+            cmd = format_command(
+                self._app._config.worktree.create,  # type: ignore[arg-type]
+                branch=branch,
+                name=wt_name,
+                base=base_branch,
+                path=wt_path,
+                repo=repo_root,
+                extra=extra,
+            )
+            self._app.call_later(self._app._send_to_terminal, cmd)
+            self._app.call_later(self._app._load_worktrees)
+            return _ok(request_id, {"path": wt_path, "branch": branch, "custom_command": True})
 
         manager = WorktreeManager(self._app._repo_root)
         new_path = await asyncio.to_thread(manager.create, branch, base_branch)
@@ -216,7 +243,8 @@ class IpcServer:
     async def handle_spawn_agent(
         self, request_id: str, params: dict
     ) -> dict:
-        """Spawn an agent in a worktree. Params: worktree_path, instruction (optional)."""
+        """Spawn an agent in a worktree. Params: worktree_path, instruction (optional),
+        skip_permissions (optional), resume_mode (optional)."""
         worktree_path = params.get("worktree_path", "")
         if not worktree_path:
             raise ValueError("worktree_path is required")
@@ -232,6 +260,15 @@ class IpcServer:
 
         future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         instruction = params.get("instruction") or params.get("initial_prompt")
+        skip_permissions = params.get("skip_permissions", True)
+        resume_mode_str = params.get("resume_mode", "new")
+        try:
+            resume_mode = ResumeMode(resume_mode_str)
+        except ValueError:
+            raise ValueError(
+                f"Invalid resume_mode: {resume_mode_str!r}. "
+                f"Must be one of: {', '.join(m.value for m in ResumeMode)}"
+            )
 
         async def _do_spawn() -> None:
             try:
@@ -240,8 +277,9 @@ class IpcServer:
                 center = self._app.query_one(CenterPanel)
                 panel = center.ensure_panel(worktree_path)
                 await panel.spawn_agent(
-                    skip_permissions=True,
+                    skip_permissions=skip_permissions,
                     agent_provider=self._app._config.agent.provider,
+                    resume_mode=resume_mode,
                     socket_path=self._socket_path,
                     instruction=instruction,
                 )
@@ -367,6 +405,32 @@ class IpcServer:
             "lines": collected,
             "total_lines": total_lines,
         })
+
+    async def handle_send_agent_input(
+        self, request_id: str, params: dict
+    ) -> dict:
+        """Send text input to a running agent's terminal. Params: worktree_path, text."""
+        worktree_path = params.get("worktree_path", "")
+        text = params.get("text", "")
+        if not worktree_path:
+            raise ValueError("worktree_path is required")
+        if not text:
+            raise ValueError("text is required and must not be empty")
+
+        from lazyagent.widgets.center_panel import CenterPanel
+
+        center = self._app.query_one(CenterPanel)
+        panel = center.get_panel(worktree_path)
+        if panel is None or not panel.has_agent:
+            raise ValueError("No running agent in this worktree")
+
+        terminal = panel.agent_terminal
+        if terminal is None or terminal.send_queue is None:
+            raise ValueError("Agent terminal is not ready")
+
+        # Append newline like the UI does for submitted text
+        await terminal.send_queue.put(["stdin", text + "\n"])
+        return _ok(request_id, {"worktree_path": worktree_path, "status": "sent"})
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/lazyagent/ipc.py
+++ b/src/lazyagent/ipc.py
@@ -171,7 +171,29 @@ class IpcServer:
     async def handle_create_worktree(
         self, request_id: str, params: dict
     ) -> dict:
-        """Create a new worktree. Params: branch, base_branch (optional), extra (optional)."""
+        """Create a new worktree.
+
+        Params:
+            branch: required, non-empty branch name.
+            base_branch: optional, defaults to "main".
+            extra: optional, only used when a custom create command is
+                configured.
+
+        Two paths:
+        - **No custom create command**: runs ``git worktree add``
+          synchronously and returns the actual path. ``extra`` is ignored
+          (with a warning in the response so callers notice).
+        - **Custom create command** (``[worktree] create = "..."`` in
+          ``.lazyagent.toml``): the command is dispatched into the user's
+          currently-selected worktree terminal and runs asynchronously.
+          ``path`` in the response is *predicted* from the modal's naming
+          convention (``<parent>/<repo>-<branch>``); the caller MUST poll
+          ``list_worktrees`` to confirm the worktree actually appeared
+          before calling ``spawn_agent`` on it. ``custom_command: true``
+          flags this contract. If no worktree is selected in the UI the
+          call fails with VALIDATION_ERROR rather than silently dropping
+          the command.
+        """
         branch = params.get("branch", "").strip()
         if not branch:
             raise ValueError("branch is required and must not be empty")
@@ -180,6 +202,16 @@ class IpcServer:
 
         if self._app._config.has_custom_create:
             from lazyagent.config import format_command
+
+            # The custom command needs a terminal to run in. Without a
+            # selected worktree, _send_to_terminal silently no-ops via a
+            # warning notify and the caller would get "success" for an
+            # operation that never happened. Reject explicitly.
+            if self._app._get_selected_worktree() is None:
+                raise ValueError(
+                    "Custom create command requires a selected worktree to "
+                    "dispatch into; none is currently selected in the UI"
+                )
 
             repo_root = self._app._repo_root
             repo_name = os.path.basename(repo_root) if repo_root else ""
@@ -200,7 +232,27 @@ class IpcServer:
             )
             self._app.call_later(self._app._send_to_terminal, cmd)
             self._app.call_later(self._app._load_worktrees)
-            return _ok(request_id, {"path": wt_path, "branch": branch, "custom_command": True})
+            return _ok(request_id, {
+                "path": wt_path,
+                "branch": branch,
+                "custom_command": True,
+                "warning": (
+                    "Path is predicted, not verified. The custom create "
+                    "command runs asynchronously in the selected worktree's "
+                    "terminal. Poll list_worktrees to confirm the worktree "
+                    "exists before calling spawn_agent on it."
+                ),
+            })
+
+        # Plain ``git worktree add`` path. Surface a warning if extra was
+        # passed but cannot be honoured — easier for an LLM caller to
+        # notice than a silent drop.
+        result: dict[str, Any] = {}
+        if extra:
+            result["warning"] = (
+                "extra= was provided but this repo has no custom create "
+                "command configured; the value was ignored."
+            )
 
         manager = WorktreeManager(self._app._repo_root)
         new_path = await asyncio.to_thread(manager.create, branch, base_branch)
@@ -208,7 +260,9 @@ class IpcServer:
         # Refresh the worktree list on the Textual thread
         self._app.call_later(self._app._load_worktrees)
 
-        return _ok(request_id, {"path": new_path, "branch": branch})
+        result["path"] = new_path
+        result["branch"] = branch
+        return _ok(request_id, result)
 
     async def handle_remove_worktree(
         self, request_id: str, params: dict
@@ -448,10 +502,15 @@ async def start_ipc_server(app: LazyAgent) -> tuple[IpcServer, str]:
     """Factory: create and start an IPC server for the given app.
 
     Returns ``(server, socket_path)``.
-    Socket is created at ``/tmp/lazyagent-{pid}/ipc.sock``.
+    Socket is created at ``/tmp/lazyagent-{pid}/ipc.sock`` with 0o700 dir
+    and 0o600 socket perms so other users on the host cannot connect to it
+    (the IPC handlers can spawn agents and remove worktrees, so an
+    unauthenticated cross-user connection is privilege escalation).
     """
     socket_dir = os.path.join(tempfile.gettempdir(), f"lazyagent-{os.getpid()}")
     os.makedirs(socket_dir, exist_ok=True)
+    # Re-apply mode in case the directory already existed with looser perms.
+    os.chmod(socket_dir, 0o700)
     socket_path = os.path.join(socket_dir, "ipc.sock")
 
     # Remove stale socket if present
@@ -462,4 +521,9 @@ async def start_ipc_server(app: LazyAgent) -> tuple[IpcServer, str]:
 
     server = IpcServer(app, socket_path)
     await server.start()
+    # start_unix_server doesn't accept a mode arg; chmod after bind.
+    try:
+        os.chmod(socket_path, 0o600)
+    except OSError:
+        pass
     return server, socket_path

--- a/src/lazyagent/mcp_server.py
+++ b/src/lazyagent/mcp_server.py
@@ -90,20 +90,30 @@ async def list_worktrees() -> list[dict]:
 
 
 @mcp.tool()
-async def create_worktree(branch: str, base_branch: str = "main") -> dict:
+async def create_worktree(
+    branch: str, base_branch: str = "main", extra: str = ""
+) -> dict:
     """Create a new git worktree with a new branch.
+
+    If the repo has a custom create command configured in ``.lazyagent.toml``
+    (``[worktree] create = "..."``), that command is run transparently —
+    same as when a user creates a worktree from the UI. This lets post-create hooks
+    (e.g. ``bun install``, copying ``.env``) run consistently.
 
     Args:
         branch: Name for the new branch.
         base_branch: Branch to base the new worktree on. Defaults to "main".
+        extra: Optional string substituted for the ``{extra}`` placeholder in
+            the custom create command template. Ignored when no custom command
+            is configured.
 
     Returns:
         Object with path and branch of the new worktree.
     """
-    return await _get_client().call(
-        "create_worktree",
-        {"branch": branch, "base_branch": base_branch},
-    )
+    params: dict[str, Any] = {"branch": branch, "base_branch": base_branch}
+    if extra:
+        params["extra"] = extra
+    return await _get_client().call("create_worktree", params)
 
 
 @mcp.tool()
@@ -127,21 +137,33 @@ async def remove_worktree(worktree_path: str, force: bool = False) -> dict:
 
 @mcp.tool()
 async def spawn_agent(
-    worktree_path: str, instruction: str | None = None
+    worktree_path: str,
+    instruction: str | None = None,
+    skip_permissions: bool = True,
+    resume_mode: str = "new",
 ) -> dict:
     """Spawn a coding agent in a worktree.
 
-    The agent runs with skip_permissions=True. Only one agent can run
-    per worktree at a time.
+    Only one agent can run per worktree at a time.
 
     Args:
         worktree_path: Absolute path of the worktree.
         instruction: Optional initial instruction passed to the agent CLI.
+        skip_permissions: If True (default), the agent runs in "dangerous" mode
+            with permission prompts bypassed. Set to False for normal mode where
+            the agent asks before sensitive actions.
+        resume_mode: Session mode — "new" (default) starts a fresh session,
+            "last" resumes the most recent session for this worktree. Interactive
+            "pick from list" mode is not supported over MCP.
 
     Returns:
         Object with worktree_path and status.
     """
-    params: dict[str, Any] = {"worktree_path": worktree_path}
+    params: dict[str, Any] = {
+        "worktree_path": worktree_path,
+        "skip_permissions": skip_permissions,
+        "resume_mode": resume_mode,
+    }
     if instruction is not None:
         params["instruction"] = instruction
     return await _get_client().call("spawn_agent", params)
@@ -195,6 +217,26 @@ async def read_agent_output(worktree_path: str, lines: int = 50) -> dict:
     return await _get_client().call(
         "read_agent_output",
         {"worktree_path": worktree_path, "lines": lines},
+    )
+
+
+@mcp.tool()
+async def send_agent_input(worktree_path: str, text: str) -> dict:
+    """Send text input to a running agent's terminal.
+
+    Use this to provide follow-up instructions, answer prompts, or approve
+    actions without stopping and re-spawning the agent.
+
+    Args:
+        worktree_path: Absolute path of the worktree.
+        text: The text to send to the agent's stdin (a newline is appended automatically).
+
+    Returns:
+        Object confirming the input was sent.
+    """
+    return await _get_client().call(
+        "send_agent_input",
+        {"worktree_path": worktree_path, "text": text},
     )
 
 

--- a/src/lazyagent/mcp_server.py
+++ b/src/lazyagent/mcp_server.py
@@ -13,6 +13,7 @@ import asyncio
 import glob
 import json
 import os
+import socket as _socket
 import tempfile
 import uuid
 from typing import Any
@@ -63,20 +64,101 @@ class IpcClient:
 _cached_client: IpcClient | None = None
 
 
+def _socket_alive(path: str) -> bool:
+    """Return True if a Unix socket at ``path`` accepts a connection.
+
+    A bare ``os.path.exists`` is not enough: a lazyagent crash leaves the
+    socket file in place but with no listener, and a stale entry would
+    poison ``_discover_socket`` until manual cleanup.
+    """
+    if not path or not os.path.exists(path):
+        return False
+    try:
+        with _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM) as s:
+            s.settimeout(0.5)
+            s.connect(path)
+            return True
+    except OSError:
+        return False
+
+
+def _walk_ancestors():
+    """Yield this process's ancestor pids, parent first.
+
+    Reads ``/proc/<pid>/status`` for the ``PPid:`` line — Linux only.
+    Other platforms get an empty walk and fall back to the mtime heuristic.
+    """
+    try:
+        pid = os.getppid()
+    except OSError:
+        return
+    seen: set[int] = set()
+    while pid > 1 and pid not in seen:
+        seen.add(pid)
+        yield pid
+        try:
+            with open(f"/proc/{pid}/status") as f:
+                next_pid = 0
+                for line in f:
+                    if line.startswith("PPid:"):
+                        try:
+                            next_pid = int(line.split()[1])
+                        except (IndexError, ValueError):
+                            next_pid = 0
+                        break
+                if next_pid <= 0:
+                    return
+                pid = next_pid
+        except OSError:
+            return
+
+
 def _discover_socket() -> str | None:
-    """Find a running lazyagent IPC socket in the default temp directory."""
-    pattern = os.path.join(tempfile.gettempdir(), "lazyagent-*/ipc.sock")
+    """Find a running lazyagent IPC socket.
+
+    Two-phase: first try to scope to the lazyagent that owns this MCP
+    process by walking ancestor pids and checking ``/tmp/lazyagent-<pid>``.
+    This prevents an MCP spawned by lazyagent A from accidentally driving
+    lazyagent B (different repo) just because B's socket has a more recent
+    mtime. Only if no ancestor matches do we fall back to "most recently
+    modified live socket" — and we *connect* to verify it's alive, not
+    just that the file exists.
+    """
+    tmp = tempfile.gettempdir()
+
+    # Phase 1: ancestor-scoped lookup.
+    for ancestor_pid in _walk_ancestors():
+        candidate = os.path.join(tmp, f"lazyagent-{ancestor_pid}", "ipc.sock")
+        if _socket_alive(candidate):
+            return candidate
+
+    # Phase 2: fall back to scanning the temp dir.
+    pattern = os.path.join(tmp, "lazyagent-*/ipc.sock")
     candidates = glob.glob(pattern)
-    # Return the most recently modified socket (likely the active instance)
-    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+
+    def _safe_mtime(p: str) -> float:
+        try:
+            return os.path.getmtime(p)
+        except OSError:
+            return 0.0
+
+    candidates.sort(key=_safe_mtime, reverse=True)
     for path in candidates:
-        if os.path.exists(path):
+        if _socket_alive(path):
             return path
     return None
 
 
 def _get_client() -> IpcClient:
+    """Return a (possibly cached) client to the lazyagent IPC server.
+
+    Invalidates the cache if the cached socket is no longer alive — this
+    matters when the user restarts lazyagent while a long-running MCP
+    process keeps running.
+    """
     global _cached_client
+    if _cached_client is not None and not _socket_alive(_cached_client._socket_path):
+        _cached_client = None
     if _cached_client is None:
         socket_path = os.environ.get("LAZYAGENT_SOCKET") or _discover_socket()
         if not socket_path:
@@ -109,20 +191,36 @@ async def create_worktree(
 ) -> dict:
     """Create a new git worktree with a new branch.
 
-    If the repo has a custom create command configured in ``.lazyagent.toml``
-    (``[worktree] create = "..."``), that command is run transparently —
-    same as when a user creates a worktree from the UI. This lets post-create hooks
-    (e.g. ``bun install``, copying ``.env``) run consistently.
+    Two modes depending on the repo's ``.lazyagent.toml``:
+
+    1. **No custom create command**: runs ``git worktree add`` synchronously.
+       The returned ``path`` exists on disk when this call returns, and
+       ``spawn_agent`` can be called on it immediately. ``extra`` is ignored
+       (a ``warning`` field is included in the response so this is visible).
+
+    2. **Custom create command** (``[worktree] create = "..."``): the
+       configured command is dispatched into the user's currently-selected
+       worktree terminal and runs *asynchronously*. The response includes
+       ``custom_command: true`` and a ``warning`` field. The returned
+       ``path`` is *predicted* from a naming convention
+       (``<parent>/<repo>-<branch>``) and is **not** verified to exist.
+       Callers MUST poll ``list_worktrees`` until the new path appears
+       before calling ``spawn_agent`` on it. If no worktree is currently
+       selected in the UI, the call fails — there is no terminal to
+       dispatch into.
 
     Args:
         branch: Name for the new branch.
         base_branch: Branch to base the new worktree on. Defaults to "main".
-        extra: Optional string substituted for the ``{extra}`` placeholder in
-            the custom create command template. Ignored when no custom command
-            is configured.
+        extra: Optional string substituted for the ``{extra}`` placeholder
+            in the custom create command template. Ignored (with a warning)
+            when no custom command is configured. Note: this value is
+            interpolated into a shell command — avoid characters that would
+            break a shell template (``;``, ``$()``, backticks, etc.).
 
     Returns:
-        Object with path and branch of the new worktree.
+        Object with ``path``, ``branch``, optional ``custom_command``, and
+        optional ``warning`` describing any caveats.
     """
     params: dict[str, Any] = {"branch": branch, "base_branch": base_branch}
     if extra:
@@ -168,7 +266,11 @@ async def spawn_agent(
             the agent asks before sensitive actions.
         resume_mode: Session mode — "new" (default) starts a fresh session,
             "last" resumes the most recent session for this worktree. Interactive
-            "pick from list" mode is not supported over MCP.
+            "pick from list" mode is not supported over MCP. **Combining
+            ``resume_mode="last"`` with ``instruction``** resumes the prior
+            session AND passes the instruction as a new turn — it does not
+            replace the prior task. For a clean restart with new instructions,
+            use the default ``resume_mode="new"``.
 
     Returns:
         Object with worktree_path and status.

--- a/src/lazyagent/mcp_server.py
+++ b/src/lazyagent/mcp_server.py
@@ -10,8 +10,10 @@ Run with: ``python3 -m lazyagent.mcp_server``
 from __future__ import annotations
 
 import asyncio
+import glob
 import json
 import os
+import tempfile
 import uuid
 from typing import Any
 
@@ -61,14 +63,26 @@ class IpcClient:
 _cached_client: IpcClient | None = None
 
 
+def _discover_socket() -> str | None:
+    """Find a running lazyagent IPC socket in the default temp directory."""
+    pattern = os.path.join(tempfile.gettempdir(), "lazyagent-*/ipc.sock")
+    candidates = glob.glob(pattern)
+    # Return the most recently modified socket (likely the active instance)
+    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    for path in candidates:
+        if os.path.exists(path):
+            return path
+    return None
+
+
 def _get_client() -> IpcClient:
     global _cached_client
     if _cached_client is None:
-        socket_path = os.environ.get("LAZYAGENT_SOCKET")
+        socket_path = os.environ.get("LAZYAGENT_SOCKET") or _discover_socket()
         if not socket_path:
             raise RuntimeError(
-                "LAZYAGENT_SOCKET environment variable is not set. "
-                "This server must be started by lazyagent."
+                "No running lazyagent instance found. "
+                "Start lazyagent first, or set LAZYAGENT_SOCKET."
             )
         _cached_client = IpcClient(socket_path)
     return _cached_client

--- a/src/lazyagent/orchestrator_prompt.py
+++ b/src/lazyagent/orchestrator_prompt.py
@@ -34,7 +34,12 @@ and git status. Call this first to understand current state.
 - **`create_worktree(branch, base_branch="main", extra="")`** — Creates a new worktree on \
 a new branch forked from `base_branch`. Use descriptive branch names \
 (e.g., `fix-auth-redirect`, `add-user-export`). The `extra` param is substituted \
-into the `{extra}` placeholder of a custom create command (if configured).
+into the `{extra}` placeholder of a custom create command (if configured). \
+**Important:** if the response contains `custom_command: true`, the worktree is being \
+created asynchronously in the user's terminal and the returned `path` is *predicted*, \
+not verified. Before calling `spawn_agent` on it, poll `list_worktrees` until the new \
+path actually appears. If `extra` was ignored, the response will include a `warning` \
+field explaining why.
 - **`remove_worktree(worktree_path, force=false)`** — Removes a worktree. Will \
 fail if an agent is running — stop it first.
 
@@ -44,7 +49,10 @@ fail if an agent is running — stop it first.
 — Starts a coding agent in the given worktree. The `instruction` is the task prompt \
 the agent will execute. Make it specific and self-contained — the agent has no context \
 beyond what you write here. Set `skip_permissions=false` for normal permission mode. \
-Use `resume_mode="last"` to resume the most recent session.
+Use `resume_mode="last"` to resume the most recent session. **Note:** combining \
+`resume_mode="last"` with an `instruction` resumes the prior session and *also* sends \
+the new instruction as an additional turn — it does not replace the original task. \
+For a clean restart with new instructions, use the default `resume_mode="new"`.
 - **`stop_agent(worktree_path)`** — Kills the agent process. Use when an agent is \
 stuck, went off-track, or the task is done.
 - **`get_agent_status(worktree_path)`** — Returns status (`running`, `waiting`, \

--- a/src/lazyagent/orchestrator_prompt.py
+++ b/src/lazyagent/orchestrator_prompt.py
@@ -31,23 +31,29 @@ You are the only one with a global view. Use that to coordinate.
 
 - **`list_worktrees`** — Returns all worktrees with branch, path, agent status, \
 and git status. Call this first to understand current state.
-- **`create_worktree(branch, base_branch="main")`** — Creates a new worktree on \
+- **`create_worktree(branch, base_branch="main", extra="")`** — Creates a new worktree on \
 a new branch forked from `base_branch`. Use descriptive branch names \
-(e.g., `fix-auth-redirect`, `add-user-export`).
+(e.g., `fix-auth-redirect`, `add-user-export`). The `extra` param is substituted \
+into the `{extra}` placeholder of a custom create command (if configured).
 - **`remove_worktree(worktree_path, force=false)`** — Removes a worktree. Will \
 fail if an agent is running — stop it first.
 
 ### Agent lifecycle
 
-- **`spawn_agent(worktree_path, instruction?)`** — Starts a coding agent in the \
-given worktree. The `instruction` is the task prompt the agent will execute. Make \
-it specific and self-contained — the agent has no context beyond what you write here.
+- **`spawn_agent(worktree_path, instruction?, skip_permissions=true, resume_mode="new")`** \
+— Starts a coding agent in the given worktree. The `instruction` is the task prompt \
+the agent will execute. Make it specific and self-contained — the agent has no context \
+beyond what you write here. Set `skip_permissions=false` for normal permission mode. \
+Use `resume_mode="last"` to resume the most recent session.
 - **`stop_agent(worktree_path)`** — Kills the agent process. Use when an agent is \
 stuck, went off-track, or the task is done.
 - **`get_agent_status(worktree_path)`** — Returns status (`running`, `waiting`, \
 `idle`, `no_agent`), confidence level, and detail text.
 - **`read_agent_output(worktree_path, lines=50)`** — Reads recent terminal output. \
 Use this to check progress, see errors, or verify completion.
+- **`send_agent_input(worktree_path, text)`** — Sends text input to a running \
+agent's terminal (a newline is appended automatically). Use this to answer prompts, \
+approve actions, or provide follow-up instructions without restarting the agent.
 
 ## Workflow
 
@@ -80,7 +86,9 @@ read_agent_output(worktree_path)  →  what has it done so far?
 
 If an agent is **waiting for approval** or **stuck**:
 - Read its output to understand the situation.
-- If you can resolve it, stop and re-spawn with refined instructions.
+- If the agent is waiting for simple input (e.g., a yes/no prompt), use \
+`send_agent_input` to respond directly.
+- If the task needs major course correction, stop and re-spawn with refined instructions.
 - If it needs human judgement, escalate to the user.
 
 ### 5. Verify & clean up

--- a/src/lazyagent/pty_emulator.py
+++ b/src/lazyagent/pty_emulator.py
@@ -98,9 +98,17 @@ class PtyEmulator:
         decoder = codecs.getincrementaldecoder("utf-8")("replace")
         loop = asyncio.get_running_loop()
 
+        # Optional raw-stream capture for debugging terminal-rendering issues.
+        # Set LAZYAGENT_PTY_CAPTURE=/path/to/file to log every byte the PTY
+        # emits to that file. Append mode; safe to leave on across runs.
+        capture_path = os.environ.get("LAZYAGENT_PTY_CAPTURE")
+        capture_file = open(capture_path, "ab", buffering=0) if capture_path else None
+
         def on_output():
             try:
                 raw = self.p_out.read(65536)
+                if capture_file is not None:
+                    capture_file.write(raw)
                 self.data_or_disconnect = decoder.decode(raw)
                 self.event.set()
             except Exception:

--- a/src/lazyagent/pty_emulator.py
+++ b/src/lazyagent/pty_emulator.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import codecs
 import fcntl
+import logging
 import os
 import pty
 import re
@@ -20,6 +21,8 @@ import signal
 import struct
 import termios
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 # Constants previously imported from textual-terminal
 DECSET_PREFIX = "\x1b[?"
@@ -101,14 +104,32 @@ class PtyEmulator:
         # Optional raw-stream capture for debugging terminal-rendering issues.
         # Set LAZYAGENT_PTY_CAPTURE=/path/to/file to log every byte the PTY
         # emits to that file. Append mode; safe to leave on across runs.
+        # A bad path must not take down the agent: log and continue without
+        # capture rather than letting OSError propagate out of _run.
         capture_path = os.environ.get("LAZYAGENT_PTY_CAPTURE")
-        capture_file = open(capture_path, "ab", buffering=0) if capture_path else None
+        capture_file = None
+        if capture_path:
+            try:
+                capture_file = open(capture_path, "ab", buffering=0)
+            except OSError as e:
+                log.warning(
+                    "LAZYAGENT_PTY_CAPTURE: failed to open %s: %s — disabling capture",
+                    capture_path,
+                    e,
+                )
 
         def on_output():
             try:
                 raw = self.p_out.read(65536)
                 if capture_file is not None:
-                    capture_file.write(raw)
+                    # Capture is best-effort debug output; don't let it
+                    # break the read loop. A close/cancel race can leave
+                    # the reader callback firing after the file is closed,
+                    # which raises ValueError, not OSError.
+                    try:
+                        capture_file.write(raw)
+                    except (OSError, ValueError):
+                        pass
                 self.data_or_disconnect = decoder.decode(raw)
                 self.event.set()
             except Exception:
@@ -142,6 +163,12 @@ class PtyEmulator:
                         self.p_out.write(f"\x1b[<65;{x};{y}M".encode())
         except asyncio.CancelledError:
             pass
+        finally:
+            if capture_file is not None:
+                try:
+                    capture_file.close()
+                except OSError:
+                    pass
 
     async def _send_data(self) -> None:
         """Forward decoded output or disconnect signal to the send queue."""

--- a/src/lazyagent/pyte_patch.py
+++ b/src/lazyagent/pyte_patch.py
@@ -1,4 +1,5 @@
-"""Monkey-patch pyte to support SGR 2 (dim/faint) text.
+"""Monkey-patch pyte to support SGR 2 (dim/faint) text and to filter newer
+escape sequences pyte 0.8.2 doesn't recognize.
 
 Import this module before any pyte usage. It:
 
@@ -11,6 +12,17 @@ Import this module before any pyte usage. It:
 
 3. Overrides ``pyte.Screen.select_graphic_rendition`` so that SGR 22 resets
    **both** bold and dim (per ANSI spec, SGR 22 = "normal intensity").
+
+4. Wraps ``pyte.streams.Stream.feed`` with a state-machine pre-filter that:
+   - Drops DCS sequences (``\\eP...\\e\\``). Claude Code v2.1.x uses these for
+     tmux passthrough of OSC 9 notifications; without filtering, the literal
+     content (``tmux;]9;Claude is waiting for your input``) leaks into the
+     screen because pyte has no DCS dispatch.
+   - Strips colon-separated CSI sub-parameters (``\\e[4:3m`` → ``\\e[4m``).
+     Pyte's CSI parser only knows ``;`` as a separator; on ``:`` it dispatches
+     an empty handler and breaks, leaking the trailing bytes as drawn text.
+     Affects kitty extended underline (``\\e[4:Nm``), kitty keyboard reports
+     (``\\e[<code>;<mods>:<event>u``), and ITU T.416 separators.
 """
 
 from __future__ import annotations
@@ -19,6 +31,7 @@ from typing import NamedTuple
 
 import pyte.graphics
 import pyte.screens
+import pyte.streams
 
 # ---------------------------------------------------------------------------
 # 1. Extended Char with `dim` field
@@ -66,3 +79,145 @@ def _patched_sgr(self: pyte.screens.Screen, *attrs: int) -> None:
 
 
 pyte.screens.Screen.select_graphic_rendition = _patched_sgr
+
+# ---------------------------------------------------------------------------
+# 4. Stream-level pre-filter for DCS and CSI sub-parameters
+# ---------------------------------------------------------------------------
+
+
+class _StreamFilter:
+    """Per-stream state machine that scrubs DCS and CSI ``:``-sub-params.
+
+    Holds escape state across ``feed()`` chunks so sequences split mid-byte
+    are still handled correctly. Drops complete DCS (``\\eP...\\e\\``)
+    sequences entirely. Buffers each CSI sequence and rewrites it as a
+    unit, dropping any ``;``-separated atom that contains ``:`` so neither
+    the leading number nor its sub-parameters reach pyte.
+
+    Why drop the whole atom: keeping just the leading number is wrong for
+    SGR — e.g. ``\\e[4:0m`` semantically means "underline OFF" (extended
+    SGR), but rewriting to ``\\e[4m`` would apply legacy "underline ON".
+    Dropping the whole atom leaves the underline state unchanged, which
+    is the safe behaviour when we cannot honour the sub-parameter.
+    """
+
+    NORMAL = 0
+    SAW_ESC = 1
+    IN_CSI = 2
+    IN_DCS = 3
+    DCS_SAW_ESC = 4
+
+    __slots__ = ("state", "csi_buf")
+
+    def __init__(self) -> None:
+        self.state = self.NORMAL
+        self.csi_buf = ""
+
+    def filter(self, data: str) -> str:  # noqa: A003 — match common naming
+        out: list[str] = []
+        state = self.state
+        csi_buf = self.csi_buf
+        for ch in data:
+            if state == self.NORMAL:
+                if ch == "\x1b":
+                    state = self.SAW_ESC
+                else:
+                    out.append(ch)
+            elif state == self.SAW_ESC:
+                if ch == "[":
+                    csi_buf = ""
+                    state = self.IN_CSI
+                elif ch == "P":
+                    # DCS: discard \eP and everything until ST (\e\\).
+                    state = self.IN_DCS
+                else:
+                    # Other ESC-prefixed sequences pass through unchanged
+                    # (pyte handles them, e.g. \eD, \eM, \eOA, \e]...).
+                    out.append("\x1b" + ch)
+                    state = self.NORMAL
+            elif state == self.IN_CSI:
+                if "\x40" <= ch <= "\x7e":  # CSI final byte (0x40–0x7E)
+                    out.append(_rewrite_csi(csi_buf, ch))
+                    csi_buf = ""
+                    state = self.NORMAL
+                else:
+                    csi_buf += ch
+            elif state == self.IN_DCS:
+                if ch == "\x1b":
+                    state = self.DCS_SAW_ESC
+                # else: content byte, drop
+            elif state == self.DCS_SAW_ESC:
+                # In tmux DCS passthrough, literal ESCs in the inner content
+                # are doubled (\e\e). The terminator is a single \e\\. So
+                # \e<not-backslash> means the previous \e was either the
+                # first half of a doubled-escape or stray content — either
+                # way, we are not at the terminator.
+                if ch == "\\":
+                    state = self.NORMAL
+                else:
+                    state = self.IN_DCS
+        self.state = state
+        self.csi_buf = csi_buf
+        return "".join(out)
+
+
+def _rewrite_csi(params: str, final: str) -> str:
+    """Rewrite a CSI sequence so pyte 0.8.2 parses it cleanly.
+
+    ``params`` is everything between ``\\e[`` and the final byte (it may
+    include a leading private/intermediate marker). ``final`` is the final
+    byte. We do three things:
+
+    1. **Drop entirely any CSI that starts with** ``<``, ``=``, **or** ``>``.
+       These prefix bytes mark xterm/kitty extensions pyte does not
+       implement. Worse, pyte's parser silently *strips* the ``>`` (it's
+       in ``SP_OR_GT``) and dispatches the remainder as if it were a
+       standard CSI — so ``\\e[>4m`` (xterm modifyOtherKeys mode) gets
+       misread as ``\\e[4m`` = SGR 4 = underline ON, which then bleeds
+       across every subsequent blank cell pyte writes (visible as long
+       horizontal lines spanning the panel). ``<`` and ``=`` fall through
+       to the no-op ``debug`` dispatch and break out of CSI early,
+       leaking the trailing bytes as drawn text (e.g. the stray ``u``
+       from kitty's ``\\e[<u`` pop). Dropping these sequences entirely
+       is the only correct option until pyte gains real support.
+
+    2. Preserve ``?`` private-CSI prefix. Pyte handles it correctly
+       (mode set / reset).
+
+    3. Drop ``;``-separated atoms that contain ``:`` (extended SGR
+       sub-params). Keeping just the leading number would invert the
+       semantics of e.g. ``\\e[4:0m`` (off → on).
+    """
+    if params and params[0] in "<=>":
+        return ""
+
+    prefix = ""
+    rest = params
+    if rest and rest[0] == "?":
+        prefix = "?"
+        rest = rest[1:]
+
+    if ":" not in rest:
+        return f"\x1b[{prefix}{rest}{final}"
+
+    atoms = rest.split(";")
+    kept = [a for a in atoms if ":" not in a]
+    if not kept:
+        # Bare \e[m would be SGR 0 / full reset — too aggressive.
+        # Emit nothing so screen state stays intact.
+        return ""
+    return f"\x1b[{prefix}{';'.join(kept)}{final}"
+
+
+_orig_feed = pyte.streams.Stream.feed
+
+
+def _patched_feed(self: pyte.streams.Stream, data: str) -> None:
+    flt: _StreamFilter | None = getattr(self, "_lazyagent_filter", None)
+    if flt is None:
+        flt = _StreamFilter()
+        self._lazyagent_filter = flt
+    _orig_feed(self, flt.filter(data))
+
+
+pyte.streams.Stream.feed = _patched_feed

--- a/src/lazyagent/pyte_patch.py
+++ b/src/lazyagent/pyte_patch.py
@@ -107,16 +107,32 @@ class _StreamFilter:
     IN_DCS = 3
     DCS_SAW_ESC = 4
 
-    __slots__ = ("state", "csi_buf")
+    # Hard caps on intra-sequence buffers so a malformed stream that opens
+    # a CSI/DCS but never finalises cannot grow memory unboundedly. 256 bytes
+    # is well above any real-world CSI (the longest standard CSI is ~16
+    # bytes); for DCS the buffer is implicit (we just drop content).
+    MAX_CSI_LEN = 256
+    MAX_DCS_LEN = 65536
+
+    # NB. We watch for the 7-bit ST terminator only (\e\\). The 8-bit C1 ST
+    # \x9c is *not* recognised: by the time bytes reach this filter they
+    # have been UTF-8 decoded by the PTY layer, and a lone 0x9C is not a
+    # valid UTF-8 lead/continuation byte so it is replaced with U+FFFD
+    # before we ever see it. Real-world DCS streams from Claude Code use
+    # \e\\, so this is fine in practice.
+
+    __slots__ = ("state", "csi_buf", "dcs_len")
 
     def __init__(self) -> None:
         self.state = self.NORMAL
         self.csi_buf = ""
+        self.dcs_len = 0
 
     def filter(self, data: str) -> str:  # noqa: A003 — match common naming
         out: list[str] = []
         state = self.state
         csi_buf = self.csi_buf
+        dcs_len = self.dcs_len
         for ch in data:
             if state == self.NORMAL:
                 if ch == "\x1b":
@@ -130,6 +146,15 @@ class _StreamFilter:
                 elif ch == "P":
                     # DCS: discard \eP and everything until ST (\e\\).
                     state = self.IN_DCS
+                    dcs_len = 0
+                elif ch == "\x1b":
+                    # Doubled ESC. xterm treats the first ESC as cancelled
+                    # and the second as the start of a new escape. Without
+                    # this branch the prior code would emit "\x1b\x1b" and
+                    # return to NORMAL, defeating the colon-stripping pass
+                    # for any CSI that follows the doubled ESC. Stay in
+                    # SAW_ESC instead and discard the cancelled first ESC.
+                    pass
                 else:
                     # Other ESC-prefixed sequences pass through unchanged
                     # (pyte handles them, e.g. \eD, \eM, \eOA, \e]...).
@@ -140,12 +165,26 @@ class _StreamFilter:
                     out.append(_rewrite_csi(csi_buf, ch))
                     csi_buf = ""
                     state = self.NORMAL
+                elif len(csi_buf) >= self.MAX_CSI_LEN:
+                    # Runaway CSI — flush as plain text and abort. Better
+                    # to garble the screen briefly than leak unbounded
+                    # state across thousands of cells.
+                    out.append("\x1b[" + csi_buf + ch)
+                    csi_buf = ""
+                    state = self.NORMAL
                 else:
                     csi_buf += ch
             elif state == self.IN_DCS:
                 if ch == "\x1b":
                     state = self.DCS_SAW_ESC
-                # else: content byte, drop
+                else:
+                    # Content byte: drop, but track length so a DCS that
+                    # never terminates does not swallow the rest of the
+                    # output forever. Cap is generous (64 KB).
+                    dcs_len += 1
+                    if dcs_len >= self.MAX_DCS_LEN:
+                        state = self.NORMAL
+                        dcs_len = 0
             elif state == self.DCS_SAW_ESC:
                 # In tmux DCS passthrough, literal ESCs in the inner content
                 # are doubled (\e\e). The terminator is a single \e\\. So
@@ -154,10 +193,12 @@ class _StreamFilter:
                 # way, we are not at the terminator.
                 if ch == "\\":
                     state = self.NORMAL
+                    dcs_len = 0
                 else:
                     state = self.IN_DCS
         self.state = state
         self.csi_buf = csi_buf
+        self.dcs_len = dcs_len
         return "".join(out)
 
 

--- a/tests/test_agent_providers.py
+++ b/tests/test_agent_providers.py
@@ -134,7 +134,10 @@ class TestClaudeMcpSettings:
         assert "mcpServers" in settings
 
         mcp_cfg = settings["mcpServers"]["lazyagent"]
-        assert mcp_cfg["command"] == "python3"
+        # sys.executable so the MCP server runs in the same interpreter
+        # lazyagent itself is running in (handles pipx/venv installs).
+        import sys
+        assert mcp_cfg["command"] == sys.executable
         assert mcp_cfg["args"] == ["-m", "lazyagent.mcp_server"]
         assert mcp_cfg["env"]["LAZYAGENT_SOCKET"] == "/tmp/test.sock"
         assert mcp_cfg["env"]["PYTHONUNBUFFERED"] == "1"

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -20,6 +20,7 @@ def _make_app(worktrees=None, agent_states=None, git_statuses=None):
     app._git_statuses = git_statuses or {}
     app._repo_root = "/tmp/repo"
     app._config.agent.provider = "claude"
+    app._config.has_custom_create = False
     app._get_agent_state = MagicMock(side_effect=lambda p: app._agent_states.setdefault(p, AgentState()))
     return app
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -120,12 +120,13 @@ class TestIpcClient:
 
 
 class TestGetClient:
-    def test_raises_when_env_not_set(self):
+    def test_raises_when_no_socket_found(self):
         with patch.dict(os.environ, {}, clear=True):
             # Ensure LAZYAGENT_SOCKET is not set
             os.environ.pop("LAZYAGENT_SOCKET", None)
-            with pytest.raises(RuntimeError, match="LAZYAGENT_SOCKET"):
-                _get_client()
+            with patch("lazyagent.mcp_server._discover_socket", return_value=None):
+                with pytest.raises(RuntimeError, match="No running lazyagent"):
+                    _get_client()
 
     def test_returns_client_when_env_set(self):
         with patch.dict(os.environ, {"LAZYAGENT_SOCKET": "/tmp/test.sock"}):

--- a/tests/test_pyte_patch.py
+++ b/tests/test_pyte_patch.py
@@ -310,3 +310,77 @@ class TestPrivateCSIMarkers:
         assert screen.cursor.hidden is False
         stream.feed("\x1b[?25l")
         assert screen.cursor.hidden is True
+
+
+class TestDoubledEscape:
+    """Doubled ESC outside DCS context (xterm cancel-and-restart).
+
+    A naive filter would emit both ESCs literally and return to NORMAL,
+    bypassing the colon-stripping pass for any CSI that follows. Verify
+    the second ESC is treated as the start of a new escape and the
+    sub-param filter still fires.
+    """
+
+    def test_doubled_esc_then_subparam_does_not_leak(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        # \x1b\x1b[4:0m — second ESC must be picked up as a new escape
+        # introducer and the colon atom dropped. Without the fix, "4:0m"
+        # could leak as drawn text or wrongly enable underline.
+        stream.feed("a\x1b\x1b[4:0mb")
+        assert _row_text(screen).rstrip() == "ab"
+        assert screen.buffer[0][0].underscore is False
+        assert screen.buffer[0][1].underscore is False
+
+    def test_doubled_esc_then_csi_color(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        stream.feed("\x1b\x1b[31mred")
+        assert _row_text(screen).rstrip() == "red"
+        assert screen.buffer[0][0].fg == "red"
+
+    def test_triple_esc_then_csi(self):
+        """Three ESCs in a row: first two cancel, third starts escape."""
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        stream.feed("\x1b\x1b\x1b[31mred")
+        assert _row_text(screen).rstrip() == "red"
+        assert screen.buffer[0][0].fg == "red"
+
+
+class TestRunawayBuffers:
+    """A malformed stream that opens CSI/DCS and never closes must not
+    grow memory unboundedly. We assert against filter state directly
+    because the recovery side-effect (flushing accumulated bytes as text)
+    can scroll the visible screen, making screen-based assertions awkward.
+    """
+
+    def _filter(self):
+        from lazyagent.pyte_patch import _StreamFilter
+        return _StreamFilter()
+
+    def test_csi_buffer_is_bounded(self):
+        flt = self._filter()
+        # Feed a CSI that never finalises, well past the cap.
+        flt.filter("\x1b[" + "9;" * 500)
+        assert len(flt.csi_buf) <= flt.MAX_CSI_LEN
+
+    def test_csi_runaway_recovers_to_normal(self):
+        flt = self._filter()
+        flt.filter("\x1b[" + "9;" * 500)
+        # After the cap is hit the filter must abort CSI and return to
+        # NORMAL so subsequent input is processed correctly.
+        out = flt.filter("\x1b[31mX")
+        assert "\x1b[31mX" in out
+        assert flt.state == flt.NORMAL
+
+    def test_dcs_runaway_recovers_to_normal(self):
+        flt = self._filter()
+        # Feed a DCS that never terminates, well past the 64 KB cap.
+        flt.filter("\x1bP" + "x" * 100000)
+        # After the cap is hit the filter must abort DCS and return to
+        # NORMAL. Subsequent properly-terminated DCS is dropped, and text
+        # after it is rendered.
+        out = flt.filter("\x1bPpayload\x1b\\after")
+        assert "after" in out
+        assert flt.state == flt.NORMAL

--- a/tests/test_pyte_patch.py
+++ b/tests/test_pyte_patch.py
@@ -81,3 +81,232 @@ class TestSGRIntegration:
 
         normal_char = screen.buffer[0][3]
         assert normal_char.dim is False
+
+
+def _row_text(screen: "pyte.Screen", row: int = 0) -> str:
+    """Return the visible contents of a screen row as a string."""
+    line = screen.buffer[row]
+    cols = max(line.keys()) + 1 if line else 0
+    return "".join(line[x].data for x in range(cols))
+
+
+class TestDCSStripping:
+    """DCS passthrough sequences (\\eP...\\e\\) must be discarded entirely.
+
+    Claude Code v2.1.x wraps OSC 9 notifications inside tmux DCS passthrough.
+    Without filtering, the inner content (``tmux;]9;Claude is waiting...``)
+    leaks onto the screen because pyte 0.8.2 has no DCS handler.
+    """
+
+    def test_simple_dcs_dropped(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        # Plain DCS with single ST terminator (\e\\)
+        stream.feed("before\x1bPanything\x1b\\after")
+        assert _row_text(screen).rstrip() == "beforeafter"
+
+    def test_tmux_passthrough_dropped(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        # The actual sequence Claude Code emits: tmux DCS wrapping OSC 9.
+        # Inner ESCs are doubled per tmux passthrough rules.
+        stream.feed(
+            "X"
+            "\x1bPtmux;\x1b\x1b]9;Claude is waiting for your input\x1b\x1b\\\x1b\\"
+            "Y"
+        )
+        assert _row_text(screen).rstrip() == "XY"
+
+    def test_dcs_split_across_chunks(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        stream.feed("hi\x1bPtmux;")
+        stream.feed("payload")
+        stream.feed("\x1b\\done")
+        assert _row_text(screen).rstrip() == "hidone"
+
+    def test_lone_esc_split_across_chunks(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        stream.feed("a\x1b")  # ESC at end of chunk
+        stream.feed("[31mred")  # CSI continues in next chunk
+        # Should render "ared" with red fg, not "a[31mred" as plain text
+        assert _row_text(screen).rstrip() == "ared"
+        assert screen.buffer[0][1].fg == "red"
+
+
+class TestCSISubparamStripping:
+    """CSI ``:`` sub-parameters must be stripped before reaching pyte.
+
+    Pyte's CSI parser only knows ``;`` as a separator. When it hits ``:`` it
+    dispatches an empty handler and breaks out of the parser, leaking the
+    trailing bytes (e.g. ``3m``, ``1u``) as drawn text.
+    """
+
+    def test_kitty_extended_underline_does_not_leak(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        # \e[4:3m = curly underline (kitty/VTE extended SGR). Without the
+        # patch, "3mhello" would appear; with it, "hello" without underline
+        # (we drop the atom entirely rather than risk wrong-direction toggle).
+        stream.feed("\x1b[4:3mhello")
+        assert _row_text(screen).rstrip() == "hello"
+        assert screen.buffer[0][0].underscore is False
+
+    def test_extended_underline_off_does_not_turn_on(self):
+        """Regression: \\e[4:0m must NOT enable underline.
+
+        \\e[4:0m is extended SGR "underline OFF". A naive rewrite to
+        \\e[4m would flip the meaning to "underline ON", causing a
+        subsequent screen-clear to fill every cell with underlined
+        spaces (the long horizontal lines bug).
+        """
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        stream.feed("\x1b[4:0mhi")
+        assert screen.buffer[0][0].underscore is False
+        assert screen.buffer[0][1].underscore is False
+
+    def test_clear_screen_with_active_underline_does_not_smear(self):
+        """If \\e[4:0m wrongly turned underline on, \\e[2J would stamp
+        underline=True on every cell. Verify clean state after clear."""
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        # Turn on legacy underline, then "turn off" via extended SGR,
+        # then clear screen and write text.
+        stream.feed("\x1b[4mUNDER\x1b[4:0m\x1b[2J\x1b[Hclean")
+        # Cells beyond "clean" should not be underlined
+        assert screen.buffer[0][10].underscore is False
+        assert screen.buffer[5][20].underscore is False
+
+    def test_kitty_keyboard_report_does_not_leak(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        # \e[97;5:1u — the ;5:1 atom contains ':' and is dropped, leaving
+        # \e[97u which is a pyte 'restore cursor' (no-op without saved pos).
+        stream.feed("text\x1b[97;5:1umore")
+        assert "1u" not in _row_text(screen)
+        assert "more" in _row_text(screen)
+
+    def test_subparam_atom_dropped_in_middle(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        # \e[1;4:3;31m → bold, curly-underline (atom dropped), red fg.
+        # After filtering: \e[1;31m → bold + red, no underline.
+        stream.feed("\x1b[1;4:3;31mX")
+        ch = screen.buffer[0][0]
+        assert ch.data == "X"
+        assert ch.bold is True
+        assert ch.underscore is False
+        assert ch.fg == "red"
+
+    def test_all_atoms_dropped_emits_nothing(self):
+        """\\e[4:0m alone (single atom, all subparams) must emit nothing,
+        not a bare \\e[m which pyte interprets as SGR 0 (reset all)."""
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        # Set bold + red, then a single-atom subparam'd SGR, then write.
+        # If we wrongly emitted \e[m, bold and red would be reset.
+        stream.feed("\x1b[1;31m\x1b[4:0mX")
+        ch = screen.buffer[0][0]
+        assert ch.bold is True
+        assert ch.fg == "red"
+
+    def test_plain_csi_unchanged(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        stream.feed("\x1b[1;31mbold red")
+        ch = screen.buffer[0][0]
+        assert ch.bold is True
+        assert ch.fg == "red"
+
+    def test_private_csi_with_subparam(self):
+        """Private CSI (\\e[?...) with a subparam must keep the '?'."""
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        # \e[?25h shows cursor, plain — must still work
+        stream.feed("\x1b[?25h")
+        assert screen.cursor.hidden is False
+        stream.feed("\x1b[?25l")
+        assert screen.cursor.hidden is True
+
+    def test_subparam_split_across_chunks(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        stream.feed("\x1b[4:")  # CSI starts, hits ':' at boundary
+        stream.feed("3mhi")
+        # Atom dropped, so "hi" rendered without underline
+        assert _row_text(screen).rstrip() == "hi"
+        assert screen.buffer[0][0].underscore is False
+
+
+class TestPrivateCSIMarkers:
+    """``<`` and ``=`` private CSI markers must not leak.
+
+    Pyte's CSI parser only knows ``?`` (private mode) and ``>`` (in
+    SP_OR_GT). For ``<`` and ``=`` it falls through to the debug no-op
+    and breaks out of CSI parsing, leaking the rest of the sequence as
+    drawn text. Claude Code's kitty-keyboard exit (``\\e[<u``) hits this
+    and was the source of the stray "u" in the input area.
+    """
+
+    def test_kitty_keyboard_pop_does_not_leak_u(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        stream.feed("hello\x1b[<uworld")
+        # Without the patch, "uworld" appears; with it, just "helloworld"
+        # because \e[<u is rewritten to \e[u (restore_cursor with no args).
+        assert _row_text(screen).rstrip() == "helloworld"
+
+    def test_kitty_keyboard_pop_with_count_does_not_leak(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        stream.feed("a\x1b[<5ub")
+        assert _row_text(screen).rstrip() == "ab"
+
+    def test_kitty_keyboard_push_still_works(self):
+        """``\\e[>4u`` (kitty keyboard push) must be a no-op, not a leak."""
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        stream.feed("a\x1b[>4ub")
+        assert _row_text(screen).rstrip() == "ab"
+
+    def test_xterm_modifyotherkeys_does_not_set_underline(self):
+        """Regression: ``\\e[>4m`` (xterm modifyOtherKeys reset) must NOT
+        enable underline. Pyte's parser silently strips ``>`` and would
+        otherwise dispatch SGR 4. Claude Code emits this on every prompt
+        cycle; misdispatch causes underline to leak across every blank
+        cell pyte writes (long horizontal lines spanning the panel).
+        """
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        stream.feed("\x1b[>4m hello \x1b[2J\x1b[Hclean")
+        # Cells beyond "clean" must not be underlined
+        assert screen.buffer[0][10].underscore is False
+        assert screen.buffer[10][50].underscore is False
+
+    def test_xterm_modifyotherkeys_set_does_not_set_underline_or_dim(self):
+        """``\\e[>4;2m`` would otherwise dispatch as SGR 4, 2 (underline + dim)."""
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        stream.feed("\x1b[>4;2mX")
+        ch = screen.buffer[0][0]
+        assert ch.data == "X"
+        assert ch.underscore is False
+        assert ch.dim is False
+
+    def test_equals_private_marker_does_not_leak(self):
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        # \e[=Nc would normally leak "Nc" — verify it's eaten cleanly.
+        stream.feed("a\x1b[=1cb")
+        assert _row_text(screen).rstrip() == "ab"
+
+    def test_question_private_csi_still_works(self):
+        """``?`` private CSI must keep its behaviour (mode set/reset)."""
+        screen = pyte.Screen(80, 24)
+        stream = pyte.Stream(screen)
+        stream.feed("\x1b[?25h")
+        assert screen.cursor.hidden is False
+        stream.feed("\x1b[?25l")
+        assert screen.cursor.hidden is True

--- a/uv.lock
+++ b/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "lazyagent"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Summary

Three related fixes for the orchestrator stack:

- **Missing MCP tools wired up** (`70b5f89`) — exposes the tools that were declared but not actually registered, and threads through parameters that were being dropped on the way to providers.
- **IPC socket auto-discovery + .mcp.json** (`539ad9b`) — adds a project-local `.mcp.json` so spawned agents pick up the lazyagent MCP server, and lets the server auto-discover the IPC socket instead of requiring a hard-coded path.
- **pyte 0.8.2 escape-sequence filter** (`635225b`) — Claude Code v2.1.x emits sequences pyte mishandles, leaking content into the panel:
  - DCS passthrough (`\eP...\e\\`) — tmux-wrapped OSC 9 notifications appeared as literal `tmux;]9;Claude is waiting...` text.
  - CSI `:` sub-parameters (`\e[4:3m`, `\e[97;5:1u`) — parser breaks on `:` and leaks trailing bytes as drawn text.
  - `<` / `=` / `>` private CSI markers — pyte silently strips `>`, misdispatching `\e[>4m` as SGR 4 (underline) which then bleeds across every blank cell on screen-clear (the long-horizontal-lines bug).

The pyte fix runs as a stream-level pre-filter in `pyte_patch.py` before pyte's parser sees the bytes. It drops whole CSI atoms containing `:` rather than rewriting them, since rewriting `\e[4:0m` (extended SGR underline OFF) to `\e[4m` would invert the meaning to underline ON.

Also adds `LAZYAGENT_PTY_CAPTURE=/path/to/file` for capturing raw PTY bytes when debugging future rendering issues.

## Test plan

- [ ] `uv run pytest tests/test_pyte_patch.py` — covers DCS stripping, CSI sub-param stripping, `<`/`=`/`>` private markers, split-across-chunks state machine
- [ ] `uv run pytest tests/test_mcp_server.py tests/test_ipc.py` — MCP tool registration + IPC discovery
- [ ] Manual: spawn a Claude Code v2.1.x agent in a worktree and confirm no `tmux;]9;...` leaks, no stray `u` after kitty keyboard pop, no horizontal underline lines after screen clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)