### PR TITLE
fix(tui): hide newly-mounted WorktreePanel until activated

### DIFF
--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -188,15 +188,30 @@ class LazyAgent(App):
         if panel:
             panel.update_git_status(gs, wt.display_branch)
 
+    @work(thread=True, exclusive=True, group="diff_refresh")
     def _refresh_selected_diff(self) -> None:
-        """Refresh the diff tab for the currently selected worktree."""
+        """Refresh the diff tab for the currently selected worktree.
+
+        Runs `git diff` in a worker thread so it doesn't block the message
+        pump on every navigation. ``exclusive=True`` cancels any in-flight
+        refresh when the user moves selection again — we only care about
+        the diff for the worktree that's *currently* selected.
+        """
         wt = self._selected_worktree
         if wt is None:
             return
-        center = self.query_one(CenterPanel)
-        panel = center.get_panel(wt.path)
+        diff_text = WorktreeManager.get_diff(wt.path)
+        self.call_from_thread(self._apply_diff, wt.path, diff_text)
+
+    def _apply_diff(self, worktree_path: str, diff_text: str) -> None:
+        """Apply diff text to the panel — runs on the main thread."""
+        if (
+            self._selected_worktree is None
+            or self._selected_worktree.path != worktree_path
+        ):
+            return  # selection changed; drop the stale result
+        panel = self.query_one(CenterPanel).get_panel(worktree_path)
         if panel:
-            diff_text = WorktreeManager.get_diff(wt.path)
             panel.update_diff(diff_text)
 
     @work(thread=True)

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -224,16 +224,16 @@ class LazyAgent(App):
 
     # --- Navigation ---
 
-    def on_list_view_highlighted(self, event: WorktreeList.Highlighted) -> None:
+    async def on_list_view_highlighted(self, event: WorktreeList.Highlighted) -> None:
         center = self.query_one(CenterPanel)
         if event.item is not None and isinstance(event.item, OrchestratorListItem):
             self._orchestrator_selected = True
             self._selected_worktree = None
-            center.switch_to_orchestrator(self._repo_root)
+            await center.switch_to_orchestrator(self._repo_root)
         elif event.item is not None and isinstance(event.item, WorktreeListItem):
             self._orchestrator_selected = False
             self._selected_worktree = event.item.worktree
-            center.switch_to(event.item.worktree.path)
+            await center.switch_to(event.item.worktree.path)
             self._push_git_status_to_selected_panel()
             self._refresh_selected_diff()
             self._refresh_pr_status()
@@ -305,7 +305,7 @@ class LazyAgent(App):
             if result is not None and worktree is not None:
                 center = self.query_one(CenterPanel)
                 # switch_to (not just ensure_panel) so the panel is visible
-                panel = center.switch_to(worktree.path)
+                panel = await center.switch_to(worktree.path)
                 await panel.spawn_agent(
                     skip_permissions=result.skip_permissions,
                     agent_provider=self._config.agent.provider,
@@ -328,7 +328,7 @@ class LazyAgent(App):
         async def on_spawn_dismiss(result: SpawnResult | None) -> None:
             if result is not None:
                 center = self.query_one(CenterPanel)
-                panel = center.switch_to_orchestrator(self._repo_root)
+                panel = await center.switch_to_orchestrator(self._repo_root)
                 await panel.spawn_agent(
                     skip_permissions=result.skip_permissions,
                     agent_provider=self._config.agent.provider,
@@ -541,7 +541,8 @@ class LazyAgent(App):
             return
         panel = self.query_one(CenterPanel).get_panel(wt.path)
         if panel is None:
-            panel = self.query_one(CenterPanel).switch_to(wt.path)
+            self.notify(f"No terminal available. Run manually:\n{cmd}", severity="warning", timeout=8)
+            return
         try:
             terminal = panel.query_one("#terminal-widget")
             # send_queue is an asyncio.Queue — must use put_nowait from sync context

--- a/src/lazyagent/ipc.py
+++ b/src/lazyagent/ipc.py
@@ -340,7 +340,7 @@ class IpcServer:
                 from lazyagent.widgets.center_panel import CenterPanel
 
                 center = self._app.query_one(CenterPanel)
-                panel = center.ensure_panel(worktree_path)
+                panel = await center.ensure_panel(worktree_path)
                 await panel.spawn_agent(
                     skip_permissions=skip_permissions,
                     agent_provider=self._app._config.agent.provider,

--- a/src/lazyagent/widgets/center_panel.py
+++ b/src/lazyagent/widgets/center_panel.py
@@ -307,7 +307,11 @@ class CenterPanel(Container):
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
-        self._panels: dict[str, str] = {}  # worktree_path -> panel DOM id
+        # worktree_path -> panel widget. Stored by instance (not DOM id) so we
+        # can reserve the slot before ContentSwitcher.add_content's await
+        # completes; concurrent ensure_panel calls for the same key then
+        # dedupe instead of trying to mount a second widget with the same id.
+        self._panels: dict[str, Container] = {}
 
     def compose(self):
         yield Static(
@@ -318,31 +322,34 @@ class CenterPanel(Container):
 
     def _get_panel_by_key(self, key: str) -> Container | None:
         """Get an existing panel by key, or None."""
-        if key not in self._panels:
-            return None
-        panel_id = self._panels[key]
-        return self.query_one(f"#{panel_id}", Container)
+        return self._panels.get(key)
 
     def _activate_panel(self, key: str) -> None:
         """Hide placeholder and switch the ContentSwitcher to the given key."""
         self.query_one("#center-placeholder", Static).display = False
-        self.query_one("#panel-switcher", ContentSwitcher).current = self._panels[key]
+        self.query_one("#panel-switcher", ContentSwitcher).current = self._panels[key].id
 
-    def ensure_panel(self, worktree_path: str) -> WorktreePanel:
-        """Get or lazily create a WorktreePanel for the given worktree."""
-        existing = self._get_panel_by_key(worktree_path)
+    async def ensure_panel(self, worktree_path: str) -> WorktreePanel:
+        """Get or lazily create a WorktreePanel for the given worktree.
+
+        Uses ContentSwitcher.add_content (not raw mount) so the new panel is
+        hidden until ``_activate_panel`` flips it via ``current``. Raw mount
+        leaves ``display=True`` and the panel renders as a stacked sibling.
+        """
+        existing = self._panels.get(worktree_path)
         if existing is not None:
             return existing  # type: ignore[return-value]
 
         panel_id = _panel_id(worktree_path)
         panel = WorktreePanel(worktree_path, id=panel_id)
-        self.query_one("#panel-switcher", ContentSwitcher).mount(panel)
-        self._panels[worktree_path] = panel_id
+        self._panels[worktree_path] = panel
+        switcher = self.query_one("#panel-switcher", ContentSwitcher)
+        await switcher.add_content(panel, id=panel_id)
         return panel
 
-    def switch_to(self, worktree_path: str) -> WorktreePanel:
+    async def switch_to(self, worktree_path: str) -> WorktreePanel:
         """Switch the visible panel to the given worktree (creating if needed)."""
-        panel = self.ensure_panel(worktree_path)
+        panel = await self.ensure_panel(worktree_path)
         self._activate_panel(worktree_path)
         return panel
 
@@ -350,21 +357,22 @@ class CenterPanel(Container):
         """Get existing WorktreePanel or None."""
         return self._get_panel_by_key(worktree_path)  # type: ignore[return-value]
 
-    def ensure_orchestrator_panel(self, repo_root: str) -> OrchestratorPanel:
+    async def ensure_orchestrator_panel(self, repo_root: str) -> OrchestratorPanel:
         """Get or lazily create the OrchestratorPanel."""
-        existing = self._get_panel_by_key(ORCHESTRATOR_KEY)
+        existing = self._panels.get(ORCHESTRATOR_KEY)
         if existing is not None:
             return existing  # type: ignore[return-value]
 
         panel_id = "wp-orchestrator"
         panel = OrchestratorPanel(worktree_path=repo_root, id=panel_id)
-        self.query_one("#panel-switcher", ContentSwitcher).mount(panel)
-        self._panels[ORCHESTRATOR_KEY] = panel_id
+        self._panels[ORCHESTRATOR_KEY] = panel
+        switcher = self.query_one("#panel-switcher", ContentSwitcher)
+        await switcher.add_content(panel, id=panel_id)
         return panel
 
-    def switch_to_orchestrator(self, repo_root: str) -> OrchestratorPanel:
+    async def switch_to_orchestrator(self, repo_root: str) -> OrchestratorPanel:
         """Switch the visible panel to the orchestrator."""
-        panel = self.ensure_orchestrator_panel(repo_root)
+        panel = await self.ensure_orchestrator_panel(repo_root)
         self._activate_panel(ORCHESTRATOR_KEY)
         return panel
 

--- a/src/lazyagent/widgets/monitored_terminal.py
+++ b/src/lazyagent/widgets/monitored_terminal.py
@@ -10,6 +10,11 @@ from lazyagent.widgets.scrollable_terminal import ScrollableTerminal
 
 _HANG_SECONDS = 600  # 10 minutes
 _SCAN_DEBOUNCE_SECONDS = 0.15
+# Lower bound between two consecutive screen scans. The debounce alone lets
+# scans fire every ~150 ms when output is bursty; this caps the dispatch rate
+# regardless of stream cadence so a long stream of short bursts doesn't keep
+# scanning at full speed.
+_SCAN_MIN_INTERVAL = 0.5
 
 
 class MonitoredTerminal(ScrollableTerminal):
@@ -33,6 +38,9 @@ class MonitoredTerminal(ScrollableTerminal):
         self._last_output_time: float | None = None
         self._observer = observer or AgentObserver()
         self._scan_timer: asyncio.TimerHandle | None = None
+        # Predicted dispatch time of the latest scheduled scan; used in
+        # _after_stdout_processed to enforce _SCAN_MIN_INTERVAL.
+        self._next_scan_dispatch: float = 0.0
 
     @property
     def agent_status(self) -> AgentStatus:
@@ -133,13 +141,23 @@ class MonitoredTerminal(ScrollableTerminal):
         self._on_pty_output(chars)
 
     def _after_stdout_processed(self) -> None:
-        """Debounced sentinel scanning after stdout is processed."""
+        """Schedule a debounced screen scan, throttled to _SCAN_MIN_INTERVAL.
+
+        Without the floor, bursty output causes scans to fire every ~150 ms
+        whenever the stream briefly pauses. Capping the dispatch rate keeps
+        the full-screen text join from running more than ~2 Hz regardless
+        of output cadence.
+        """
         if self._scan_timer is not None:
             self._scan_timer.cancel()
         loop = asyncio.get_running_loop()
-        self._scan_timer = loop.call_later(
-            _SCAN_DEBOUNCE_SECONDS, self._scan_screen
+        now = loop.time()
+        delay = max(
+            _SCAN_DEBOUNCE_SECONDS,
+            self._next_scan_dispatch - now,
         )
+        self._next_scan_dispatch = now + delay + _SCAN_MIN_INTERVAL
+        self._scan_timer = loop.call_later(delay, self._scan_screen)
 
     def stop(self) -> None:
         """Cancel pending scan timer, then stop the terminal."""

--- a/src/lazyagent/widgets/scrollable_terminal.py
+++ b/src/lazyagent/widgets/scrollable_terminal.py
@@ -38,6 +38,12 @@ from lazyagent.styles import SCROLLBAR_CSS
 
 _DEFAULT_MAX_SCROLLBACK = 5000
 
+# When the widget is hidden (size 0×0), defer pyte.Stream.feed and coalesce
+# chunks. Hidden widgets don't need an up-to-the-millisecond screen; the
+# observer's lifecycle scan can read a slightly-stale state. Burning CPU on
+# every stdout chunk for off-screen agents was the dominant idle cost.
+_HIDDEN_FEED_INTERVAL = 0.25
+
 
 class ScrollbackScreen(pyte.Screen):
     """pyte Screen that captures lines scrolled off the top into a deque.
@@ -125,6 +131,10 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         self._stopped = False
         self._follow_output = True  # tracks auto-scroll intent across visibility
 
+        # Deferred pyte feed while hidden. See recv() / _flush_hidden_feed.
+        self._hidden_feed_buffer: list[str] = []
+        self._hidden_feed_handle: asyncio.TimerHandle | None = None
+
         # Widget-local text selection (replaces Textual's cross-widget system)
         self._sel_start: Offset | None = None
         self._sel_end: Offset | None = None
@@ -194,6 +204,31 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         self.recv_task.cancel()
         self.emulator.stop()
         self.emulator = None
+        if self._hidden_feed_handle is not None:
+            self._hidden_feed_handle.cancel()
+            self._hidden_feed_handle = None
+        self._hidden_feed_buffer.clear()
+
+    def _flush_hidden_feed(self) -> None:
+        """Feed any chars buffered while hidden into pyte in one batch.
+
+        Called from the deferred timer, from ``on_show`` (immediate catch-up),
+        and from ``on_resize`` (so a pending resize doesn't reorder against
+        buffered output). Idempotent; safe to call with an empty buffer.
+        """
+        if self._hidden_feed_handle is not None:
+            self._hidden_feed_handle.cancel()
+            self._hidden_feed_handle = None
+        if not self._hidden_feed_buffer:
+            return
+        chars = "".join(self._hidden_feed_buffer)
+        self._hidden_feed_buffer.clear()
+        try:
+            self.stream.feed(chars)
+        except TypeError as error:
+            log.warning("could not feed:", error)
+        # Fire the post-stdout hook once per batch (debounced scan).
+        self._after_stdout_processed()
 
     # ------------------------------------------------------------------
     # Recv loop — reads PTY output and updates screen + scrollback
@@ -213,40 +248,38 @@ class ScrollableTerminal(ScrollView, can_focus=True):
                 elif cmd == "stdout":
                     chars = message[1]
 
-                    # Hook for subclasses (e.g. MonitoredTerminal)
+                    # Hook for subclasses (e.g. MonitoredTerminal) — runs per
+                    # chunk so hang detection updates last_output_time
+                    # promptly even while we're hidden.
                     self._on_stdout(chars)
 
-                    # Detect mouse tracking toggles
-                    for sep_match in re.finditer(RE_ANSI_SEQUENCE, chars):
-                        sequence = sep_match.group(0)
-                        if sequence.startswith(DECSET_PREFIX):
-                            parameters = sequence.removeprefix(
-                                DECSET_PREFIX
-                            ).split(";")
-                            if "1000h" in parameters:
-                                self.mouse_tracking = True
-                            if "1000l" in parameters:
-                                self.mouse_tracking = False
-
-                    # Use the flag instead of is_vertical_scroll_end which
-                    # returns unreliable values when the widget is hidden
-                    # (e.g. after a ContentSwitcher worktree change).
-                    was_at_bottom = self._follow_output
-
-                    # Feed to pyte (may trigger index() → scrollback capture)
-                    try:
-                        self.stream.feed(chars)
-                    except TypeError as error:
-                        log.warning("could not feed:", error)
-
-                    # Only update layout/scroll when the widget is visible.
-                    # When hidden by ContentSwitcher (display: none) the
-                    # widget's size is (0, 0); calling _update_virtual_size
-                    # would trigger _refresh_scrollbars on a zero-sized
-                    # region, and scroll_end would compute a bogus
-                    # max_scroll_y.  on_show() catches up when the widget
-                    # becomes visible again.
                     if self.size.height > 0:
+                        # Visible: process immediately so the screen and any
+                        # observer scan reflect the latest output.
+                        for sep_match in re.finditer(RE_ANSI_SEQUENCE, chars):
+                            sequence = sep_match.group(0)
+                            if sequence.startswith(DECSET_PREFIX):
+                                parameters = sequence.removeprefix(
+                                    DECSET_PREFIX
+                                ).split(";")
+                                if "1000h" in parameters:
+                                    self.mouse_tracking = True
+                                if "1000l" in parameters:
+                                    self.mouse_tracking = False
+
+                        # Use the flag instead of is_vertical_scroll_end
+                        # which returns unreliable values when the widget is
+                        # hidden (e.g. after a ContentSwitcher worktree
+                        # change).
+                        was_at_bottom = self._follow_output
+
+                        # Feed to pyte (may trigger index() → scrollback
+                        # capture)
+                        try:
+                            self.stream.feed(chars)
+                        except TypeError as error:
+                            log.warning("could not feed:", error)
+
                         self._update_virtual_size()
                         self.refresh()
                         if was_at_bottom:
@@ -254,9 +287,25 @@ class ScrollableTerminal(ScrollView, can_focus=True):
                                 animate=False, immediate=True, x_axis=False
                             )
 
-                    # Post-processing hook for subclasses (e.g. sentinel
-                    # scanning — must run regardless of visibility)
-                    self._after_stdout_processed()
+                        # Post-processing hook for subclasses (e.g. sentinel
+                        # scanning) — only runs when visible because the
+                        # hidden path coalesces and fires the hook once per
+                        # flush instead of per chunk.
+                        self._after_stdout_processed()
+                    else:
+                        # Hidden: buffer chunks and flush every
+                        # _HIDDEN_FEED_INTERVAL seconds. Avoids pyte parsing
+                        # cost per chunk for off-screen agents (e.g. running
+                        # Claude Code instances). Mouse-tracking + refresh +
+                        # scroll are all visibility-dependent, so we skip
+                        # them entirely until the flush.
+                        self._hidden_feed_buffer.append(chars)
+                        if self._hidden_feed_handle is None:
+                            loop = asyncio.get_running_loop()
+                            self._hidden_feed_handle = loop.call_later(
+                                _HIDDEN_FEED_INTERVAL,
+                                self._flush_hidden_feed,
+                            )
 
                 elif cmd == "disconnect":
                     self._on_recv_disconnect()
@@ -292,7 +341,10 @@ class ScrollableTerminal(ScrollView, can_focus=True):
     # ------------------------------------------------------------------
 
     def on_show(self) -> None:
-        """Catch up after being hidden: sync virtual size and scroll."""
+        """Catch up after being hidden: drain buffered output, sync size, scroll."""
+        # Drain anything that arrived while hidden so the first paint
+        # reflects the latest state.
+        self._flush_hidden_feed()
 
         def _restore() -> None:
             self._update_virtual_size()
@@ -594,6 +646,19 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         # the scrollback captured during that window.
         if ncol == 0 or nrow == 0:
             return
+
+        # Textual fires Resize whenever a widget enters the "shown" set,
+        # even if its dimensions are unchanged from the last visible state.
+        # Avoid the work — and avoid SIGWINCH'ing the child, which makes
+        # full-screen TUIs (Claude Code, etc.) repaint their whole UI and
+        # burst kilobytes of ANSI on every worktree switch.
+        if self.ncol == ncol and self.nrow == nrow:
+            return
+
+        # Real resize: flush any chars buffered while hidden BEFORE pyte's
+        # screen geometry changes, so the buffered output is applied at the
+        # dimensions it was produced for.
+        self._flush_hidden_feed()
 
         self.ncol = ncol
         self.nrow = nrow

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -87,7 +87,7 @@ def _patch_app_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(LazyAgent, "_refresh_pr_status", no_pr_refresh)
 
 
-def _select_worktree(app: LazyAgent, index: int) -> WorktreeInfo:
+async def _select_worktree(app: LazyAgent, index: int) -> WorktreeInfo:
     worktree_list = app.query_one(WorktreeList)
     item = [
         child
@@ -96,7 +96,7 @@ def _select_worktree(app: LazyAgent, index: int) -> WorktreeInfo:
     ][index]
     # +1 to account for the OrchestratorListItem at position 0
     worktree_list.index = index + 1
-    app.on_list_view_highlighted(WorktreeList.Highlighted(worktree_list, item))
+    await app.on_list_view_highlighted(WorktreeList.Highlighted(worktree_list, item))
     return item.worktree
 
 
@@ -109,7 +109,7 @@ async def test_switching_worktrees_restores_existing_panel_state(
     app = LazyAgent(repo_path="/repo")
 
     async with app.run_test() as pilot:
-        first = _select_worktree(app, 0)
+        first = await _select_worktree(app, 0)
         await pilot.pause()
 
         center = app.query_one(CenterPanel)
@@ -120,14 +120,14 @@ async def test_switching_worktrees_restores_existing_panel_state(
         first_tabs = first_panel.query_one("#agent-tabs", TabbedContent)
         assert first_tabs.active == "diff-tab"
 
-        second = _select_worktree(app, 1)
+        second = await _select_worktree(app, 1)
         await pilot.pause()
 
         second_panel = center.get_panel(second.path)
         assert second_panel is not None
         assert second_panel is not first_panel
 
-        _select_worktree(app, 0)
+        await _select_worktree(app, 0)
         await pilot.pause()
 
         assert center.get_panel(first.path) is first_panel
@@ -143,7 +143,7 @@ async def test_ctrl_j_uses_spawn_flow_when_selected_worktree_has_no_agent(
     app = LazyAgent(repo_path="/repo")
 
     async with app.run_test() as pilot:
-        _select_worktree(app, 1)
+        await _select_worktree(app, 1)
         await pilot.pause()
 
         app.action_spawn_agent = MagicMock()

--- a/tests/test_orchestrator_panel.py
+++ b/tests/test_orchestrator_panel.py
@@ -130,7 +130,7 @@ async def test_selecting_orchestrator_switches_to_orchestrator_panel(monkeypatch
         # Select orchestrator (index 0)
         orch_item = list(wt_list.children)[0]
         wt_list.index = 0
-        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
         await pilot.pause()
 
         assert app._orchestrator_selected is True
@@ -153,14 +153,14 @@ async def test_selecting_worktree_after_orchestrator_clears_flag(monkeypatch):
         # Select orchestrator
         orch_item = list(wt_list.children)[0]
         wt_list.index = 0
-        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
         await pilot.pause()
         assert app._orchestrator_selected is True
 
         # Select worktree
         wt_item = list(wt_list.children)[1]
         wt_list.index = 1
-        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, wt_item))
+        await app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, wt_item))
         await pilot.pause()
         assert app._orchestrator_selected is False
         assert app._selected_worktree is not None
@@ -177,7 +177,7 @@ async def test_spawn_on_orchestrator_shows_modal(monkeypatch):
         # Select orchestrator
         orch_item = list(wt_list.children)[0]
         wt_list.index = 0
-        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
         await pilot.pause()
 
         # Mock push_screen to verify modal is shown
@@ -197,7 +197,7 @@ async def test_stop_on_orchestrator_without_agent_notifies(monkeypatch):
         # Select orchestrator
         orch_item = list(wt_list.children)[0]
         wt_list.index = 0
-        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
         await pilot.pause()
 
         app.notify = MagicMock()
@@ -263,7 +263,7 @@ async def test_ctrl_j_on_orchestrator_triggers_spawn_when_no_agent(monkeypatch):
         # Select orchestrator
         orch_item = list(wt_list.children)[0]
         wt_list.index = 0
-        app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
+        await app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, orch_item))
         await pilot.pause()
 
         app.action_spawn_agent = MagicMock()


### PR DESCRIPTION
This PR bundles two changes on the same branch.

## 1. fix(tui): hide newly-mounted WorktreePanel until activated (c252fb9)

`mcp__lazyagent__spawn_agent` for a non-focused worktree caused a phantom pane stacked below the currently-visible worktree's panel — only collapsing once the user selected the spawned worktree.

Root cause: `CenterPanel.ensure_panel` used raw `ContentSwitcher.mount()`. Textual's `ContentSwitcher` only manages child `display` in `_on_mount` (once), `watch_current`, and `add_content()`. None fire for an MCP spawn that doesn't activate the panel, so the new widget kept Textual's default `display=True`.

Switched to `await ContentSwitcher.add_content(...)` (which presets `display=False` before mount). The cascade made `ensure_panel` / `switch_to` async; awaits propagated through `on_list_view_highlighted` and the spawn-dismiss callbacks. `_panels` now stores widget instances and reserves the slot before the `await` to dedupe concurrent calls (otherwise Textual raises `DuplicateIds`). Dropped the fragile `switch_to` fallback in `_send_to_terminal`.

## 2. perf(tui): cut CPU on worktree switch and hidden-agent steady state (054ca6f)

Diagnosed against a real instance running 5 active Claude Code agents across 15 worktrees, where lazyagent burned ~16% CPU at idle and spiked hard on every worktree switch. Four independent optimisations:

- **`ScrollableTerminal.on_resize` short-circuits when `(ncol, nrow)` is unchanged.** Textual posts `Resize` to every widget entering the "shown" set regardless of whether its dimensions actually changed. Without this guard we'd call `set_size` on the PTY (SIGWINCH'ing the child) and `pyte.Screen.resize` on every switch. Claude Code reacts to SIGWINCH with a full TUI repaint — kilobytes of ANSI per switch, parsed by pyte and re-rendered cell-by-cell.
- **Hidden `ScrollableTerminal`s coalesce stdout.** While `size.height == 0` we buffer chunks and feed pyte once per `_HIDDEN_FEED_INTERVAL` (250 ms) instead of per chunk. `_on_stdout` still fires per chunk so hang detection (`_last_output_time`) and observer `on_terminal_output` stay live. `on_show` and the dim-changing branch of `on_resize` both call `_flush_hidden_feed` so the screen catches up before any paint or geometry change.
- **`MonitoredTerminal._after_stdout_processed` enforces a 0.5 s floor between scan dispatches** in addition to the existing 150 ms debounce. Bursty-with-tiny-gaps output streams can no longer trigger the full-screen text join at full speed.
- **`LazyAgent._refresh_selected_diff` is now `@work(thread=True, exclusive=True)`.** The sync `git diff` subprocess that previously ran inline on every navigation handler is off the message pump; rapid sidebar movement cancels stale workers instead of queueing them. `_apply_diff` re-checks the selected worktree before applying so stale results don't overwrite the current panel.

## Test plan

- [x] `pytest` — 350 passed.
- [ ] Manual: with worktree A focused, call `mcp__lazyagent__spawn_agent` for worktree B → center column stays on A's panel (no phantom). Select B → agent already running.
- [ ] Manual: rapid arrow-key navigation through a multi-worktree sidebar — no per-switch CPU spike; `git diff` runs off-thread.
- [ ] Manual: switch into a worktree with a busy Claude Code agent — Claude doesn't repaint its UI from a SIGWINCH (no `set_size` sent when dims unchanged).
- [ ] Manual: orchestrator selection and spawn still work.
- [ ] Manual: TUI spawn flow (`s` key) still works on the selected worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)