### PR TITLE
feat(tui): support multiple agents per worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Multiple agents per worktree: press `s` to spawn additional agents in the
+  selected worktree; each gets its own tab to the left of the Diff tab. `x`
+  stops the active agent tab, and the sidebar shows a roll-up status (e.g.
+  `waiting (+1)`) when a worktree runs more than one agent
+- New `list_agents` MCP tool returning per-agent id/label/status; `spawn_agent`
+  now returns the new `agent_id` and no longer rejects a worktree that already
+  has a running agent
+- `agent_id` is now an optional parameter on `stop_agent`, `get_agent_status`,
+  `read_agent_output`, and `send_agent_input` — omit it when a worktree has a
+  single agent; supply it (else an error lists the choices) when there are
+  several. `list_worktrees` gains an `agents` array alongside the scalar
+  `agent_status` roll-up
+
 ## [0.5.3] - 2026-06-17
 
 ### Fixed

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -14,7 +14,7 @@ from lazyagent.config import Config, format_command, load_config
 from lazyagent.orchestrator_prompt import compose_orchestrator_prompt
 from lazyagent.ipc import IpcServer, start_ipc_server
 from lazyagent.messages import AgentExited, AgentStatusChanged
-from lazyagent.models import AgentState, AgentStatus, GitStatus, LifecycleConfidence, WorktreeInfo
+from lazyagent.models import AgentState, AgentStatus, GitStatus, WorktreeInfo
 from lazyagent.widgets.center_panel import CenterPanel
 from lazyagent.widgets.help_modal import HelpModal
 from lazyagent.widgets.create_worktree_modal import CreateWorktreeModal, CreateWorktreeResult
@@ -71,7 +71,10 @@ class LazyAgent(App):
         super().__init__()
         self.repo_path = repo_path
         self.worktrees: list[WorktreeInfo] = []
-        self._agent_states: dict[str, AgentState] = {}
+        # Two-level registry: outer key is a worktree path (or ORCHESTRATOR_KEY),
+        # inner maps agent id -> state. The orchestrator (and any single-agent
+        # caller) uses agent id "".
+        self._agent_states: dict[str, dict[str, AgentState]] = {}
         self._git_statuses: dict[str, GitStatus] = {}
         self._selected_worktree: WorktreeInfo | None = None
         self._orchestrator_selected: bool = False
@@ -149,11 +152,30 @@ class LazyAgent(App):
             return wt_list.highlighted_child.worktree
         return None
 
-    def _get_agent_state(self, key: str) -> AgentState:
-        """Get or create AgentState for a worktree path or ORCHESTRATOR_KEY."""
-        if key not in self._agent_states:
-            self._agent_states[key] = AgentState()
-        return self._agent_states[key]
+    def _get_agent_state(self, key: str, agent_id: str = "") -> AgentState:
+        """Get or create the AgentState for one agent in a worktree/orchestrator."""
+        bucket = self._agent_states.setdefault(key, {})
+        if agent_id not in bucket:
+            bucket[agent_id] = AgentState(agent_id=agent_id)
+        return bucket[agent_id]
+
+    def _worktree_agent_states(self, key: str) -> dict[str, AgentState]:
+        """All agent states for a worktree path / ORCHESTRATOR_KEY (may be empty)."""
+        return self._agent_states.get(key, {})
+
+    def _drop_agent_state(self, key: str, agent_id: str) -> None:
+        """Remove a single agent from the registry, pruning empty buckets."""
+        bucket = self._agent_states.get(key)
+        if bucket is not None:
+            bucket.pop(agent_id, None)
+            if not bucket:
+                self._agent_states.pop(key, None)
+
+    def _refresh_sidebar_agents(self, key: str) -> None:
+        """Push the worktree's current agent roll-up to the sidebar."""
+        self.query_one(WorktreeList).update_agent_states(
+            key, self._worktree_agent_states(key)
+        )
 
     def _get_any_panel(self, key: str):
         """Get the panel for a worktree path or ORCHESTRATOR_KEY."""
@@ -259,27 +281,28 @@ class LazyAgent(App):
     # --- Agent message handlers ---
 
     def on_agent_status_changed(self, event: AgentStatusChanged) -> None:
-        state = self._get_agent_state(event.worktree_path)
+        state = self._get_agent_state(event.worktree_path, event.agent_id)
         state.status = event.status
         state.confidence = event.confidence
         state.detail = event.detail
-        if event.status == AgentStatus.RUNNING:
-            panel = self._get_any_panel(event.worktree_path)
-            if panel and panel.agent_terminal:
-                state.last_output_time = panel.agent_terminal.last_output_time
-        self.query_one(WorktreeList).update_agent_state(event.worktree_path, state)
+        panel = self._get_any_panel(event.worktree_path)
+        if panel is not None and not state.label:
+            label_fn = getattr(panel, "agent_label", None)
+            if label_fn is not None:
+                state.label = label_fn(event.agent_id)
+        if event.status == AgentStatus.RUNNING and panel is not None:
+            terminal = panel.get_agent(event.agent_id)
+            if terminal:
+                state.last_output_time = terminal.last_output_time
+        self._refresh_sidebar_agents(event.worktree_path)
 
     async def on_agent_exited(self, event: AgentExited) -> None:
-        state = self._get_agent_state(event.worktree_path)
-        state.status = AgentStatus.NO_AGENT
-        state.confidence = LifecycleConfidence.LOW
-        state.detail = ""
-        state.last_output_time = None
-        self.query_one(WorktreeList).update_agent_state(event.worktree_path, state)
+        self._drop_agent_state(event.worktree_path, event.agent_id)
+        self._refresh_sidebar_agents(event.worktree_path)
 
         panel = self._get_any_panel(event.worktree_path)
         if panel is not None:
-            await panel.cleanup_agent()
+            await panel.cleanup_agent(event.agent_id)
 
         label = "Orchestrator" if event.worktree_path == ORCHESTRATOR_KEY else "Agent"
         self.notify(
@@ -292,11 +315,18 @@ class LazyAgent(App):
 
     def _check_hangs(self) -> None:
         """Periodic timer callback: check all active agents for hangs."""
-        for key, state in self._agent_states.items():
-            if state.status == AgentStatus.RUNNING:
-                panel = self._get_any_panel(key)
-                if panel and panel.agent_terminal:
-                    panel.agent_terminal.check_hang()
+        for key, bucket in self._agent_states.items():
+            panel = None
+            for agent_id, state in bucket.items():
+                if state.status != AgentStatus.RUNNING:
+                    continue
+                if panel is None:
+                    panel = self._get_any_panel(key)
+                if panel is None:
+                    break
+                terminal = panel.get_agent(agent_id)
+                if terminal:
+                    terminal.check_hang()
 
     # --- Actions ---
 
@@ -310,24 +340,21 @@ class LazyAgent(App):
             self.notify("No worktree selected", severity="warning")
             return
 
-        center = self.query_one(CenterPanel)
-        panel = center.get_panel(worktree.path)
-        if panel and panel.has_agent:
-            self.notify("Agent already running in this worktree", severity="warning")
-            return
-
         async def on_spawn_dismiss(result: SpawnResult | None) -> None:
             if result is not None and worktree is not None:
                 center = self.query_one(CenterPanel)
                 # switch_to (not just ensure_panel) so the panel is visible
                 panel = await center.switch_to(worktree.path)
-                await panel.spawn_agent(
+                agent_id = await panel.spawn_agent(
                     skip_permissions=result.skip_permissions,
                     agent_provider=self._config.agent.provider,
                     resume_mode=result.resume_mode,
                     socket_path=self._ipc_socket_path,
                     instruction=result.instruction,
                 )
+                state = self._get_agent_state(worktree.path, agent_id)
+                state.label = panel.agent_label(agent_id)
+                self._refresh_sidebar_agents(worktree.path)
 
         self.push_screen(SpawnModal(worktree.display_label, agent_provider=self._config.agent.provider), on_spawn_dismiss)
 
@@ -367,16 +394,15 @@ class LazyAgent(App):
 
         center = self.query_one(CenterPanel)
         panel = center.get_panel(worktree.path)
-        if panel is None or not panel.has_agent:
+        agent_id = panel.active_agent_id if panel else None
+        if panel is None or agent_id is None:
             self.notify("No running agent in this worktree", severity="warning")
             return
 
         # stop() cancels recv before disconnect fires, so update state directly.
-        state = self._get_agent_state(worktree.path)
-        state.status = AgentStatus.NO_AGENT
-        state.last_output_time = None
-        self.query_one(WorktreeList).update_agent_state(worktree.path, state)
-        await panel.cleanup_agent()
+        self._drop_agent_state(worktree.path, agent_id)
+        self._refresh_sidebar_agents(worktree.path)
+        await panel.cleanup_agent(agent_id)
         self.notify("Agent stopped")
 
     async def _stop_orchestrator_agent(self) -> None:
@@ -386,10 +412,8 @@ class LazyAgent(App):
             self.notify("No running orchestrator agent", severity="warning")
             return
 
-        state = self._get_agent_state(ORCHESTRATOR_KEY)
-        state.status = AgentStatus.NO_AGENT
-        state.last_output_time = None
-        self.query_one(WorktreeList).update_agent_state(ORCHESTRATOR_KEY, state)
+        self._drop_agent_state(ORCHESTRATOR_KEY, "")
+        self._refresh_sidebar_agents(ORCHESTRATOR_KEY)
         await panel.cleanup_agent()
         self.notify("Orchestrator agent stopped")
 
@@ -410,9 +434,12 @@ class LazyAgent(App):
             return
         panel = self.query_one(CenterPanel).get_panel(wt.path)
         if panel:
-            panel.switch_to_tab("agent-tab")
-            if panel.agent_terminal:
-                panel.agent_terminal.focus()
+            agent_id = panel.active_agent_id or (panel.agent_ids[-1] if panel.agent_ids else None)
+            if agent_id is not None:
+                panel.switch_to_tab(f"agent-tab-{agent_id}")
+                terminal = panel.get_agent(agent_id)
+                if terminal:
+                    terminal.focus()
             else:
                 self.action_spawn_agent()
 
@@ -501,8 +528,11 @@ class LazyAgent(App):
             self.notify("Cannot remove the main worktree", severity="error")
             return
 
-        state = self._get_agent_state(worktree.path)
-        if state.status in (AgentStatus.RUNNING, AgentStatus.WAITING):
+        states = self._worktree_agent_states(worktree.path)
+        if any(
+            s.status in (AgentStatus.RUNNING, AgentStatus.WAITING)
+            for s in states.values()
+        ):
             self.notify(
                 "Agent is running in this worktree — stop it first (x)",
                 severity="warning",

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -64,6 +64,10 @@ class LazyAgent(App):
         Binding("ctrl+j", "focus_agent", "Ctrl+J Agent", priority=True),
         Binding("ctrl+d", "focus_diff", "Ctrl+D Diff", priority=True),
         Binding("ctrl+l", "focus_terminal", "Ctrl+L Terminal", priority=True),
+        # Cycle agent tabs. Ctrl+[ can't be used — terminals send it as the ESC
+        # byte, so Textual delivers `escape`, not ctrl+left_square_bracket.
+        Binding("ctrl+right_square_bracket", "next_agent", "Next agent", priority=True),
+        Binding("ctrl+backslash", "prev_agent", "Prev agent", priority=True),
         Binding("question_mark", "help", "Help"),
     ]
 
@@ -442,6 +446,33 @@ class LazyAgent(App):
                     terminal.focus()
             else:
                 self.action_spawn_agent()
+
+    def action_next_agent(self) -> None:
+        self._cycle_agent(1)
+
+    def action_prev_agent(self) -> None:
+        self._cycle_agent(-1)
+
+    def _cycle_agent(self, delta: int) -> None:
+        """Switch focus to the next/previous agent tab, wrapping around."""
+        if self._orchestrator_selected:
+            return  # orchestrator is single-agent
+        wt = self._get_selected_worktree()
+        if not wt:
+            return
+        panel = self.query_one(CenterPanel).get_panel(wt.path)
+        if panel is None:
+            return
+        ids = panel.agent_ids
+        if len(ids) < 2:
+            return  # nothing to cycle between
+        current = panel.active_agent_id
+        idx = ids.index(current) if current in ids else 0
+        new_id = ids[(idx + delta) % len(ids)]
+        panel.switch_to_tab(f"agent-tab-{new_id}")
+        terminal = panel.get_agent(new_id)
+        if terminal:
+            terminal.focus()
 
     def action_focus_diff(self) -> None:
         wt = self._get_selected_worktree()

--- a/src/lazyagent/ipc.py
+++ b/src/lazyagent/ipc.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from lazyagent.agent_providers import ResumeMode
-from lazyagent.models import AgentStatus
+from lazyagent.models import AgentState, AgentStatus, rollup_status
 from lazyagent.worktree_manager import WorktreeManager, WorktreeManagerError
 
 if TYPE_CHECKING:
@@ -57,6 +57,7 @@ class IpcServer:
             "get_agent_status": self.handle_get_agent_status,
             "read_agent_output": self.handle_read_agent_output,
             "send_agent_input": self.handle_send_agent_input,
+            "list_agents": self.handle_list_agents,
         }
 
     @property
@@ -149,15 +150,18 @@ class IpcServer:
         """List all worktrees with agent status and git status."""
         result = []
         for wt in self._app.worktrees:
-            state = self._app._agent_states.get(wt.path)
+            bucket = self._agent_bucket(wt.path)
             git_st = self._app._git_statuses.get(wt.path)
+            rolled = rollup_status(s.status for s in bucket.values())
             entry: dict[str, Any] = {
                 "path": wt.path,
                 "branch": wt.branch,
                 "head": wt.head,
                 "is_main": wt.is_main,
                 "is_bare": wt.is_bare,
-                "agent_status": state.status.value if state else AgentStatus.NO_AGENT.value,
+                # Scalar roll-up kept for back-compat; `agents` has the detail.
+                "agent_status": rolled.value,
+                "agents": self._agents_payload(bucket),
             }
             if git_st:
                 entry["git_status"] = {
@@ -292,9 +296,12 @@ class IpcServer:
         if wt_info.is_main:
             raise ValueError("Cannot remove the main worktree")
 
-        # Reject if agent is running
-        state = self._app._agent_states.get(worktree_path)
-        if state and state.status in (AgentStatus.RUNNING, AgentStatus.WAITING):
+        # Reject if any agent is running
+        bucket = self._agent_bucket(worktree_path)
+        if any(
+            s.status in (AgentStatus.RUNNING, AgentStatus.WAITING)
+            for s in bucket.values()
+        ):
             raise ValueError("Agent is running in this worktree — stop it first")
 
         manager = WorktreeManager(self._app._repo_root)
@@ -308,8 +315,12 @@ class IpcServer:
     async def handle_spawn_agent(
         self, request_id: str, params: dict
     ) -> dict:
-        """Spawn an agent in a worktree. Params: worktree_path, instruction (optional),
-        skip_permissions (optional), resume_mode (optional)."""
+        """Spawn a NEW agent in a worktree. Params: worktree_path, instruction
+        (optional), skip_permissions (optional), resume_mode (optional).
+
+        Each call adds another agent; the new agent id is returned. Multiple
+        agents per worktree are supported.
+        """
         worktree_path = params.get("worktree_path", "")
         if not worktree_path:
             raise ValueError("worktree_path is required")
@@ -318,14 +329,10 @@ class IpcServer:
         if wt_info is None:
             raise ValueError(f"Unknown worktree: {worktree_path}")
 
-        # Reject if agent already running
-        state = self._app._agent_states.get(worktree_path)
-        if state and state.status in (AgentStatus.RUNNING, AgentStatus.WAITING):
-            raise ValueError("Agent is already running in this worktree")
-
-        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
         instruction = params.get("instruction") or params.get("initial_prompt")
         skip_permissions = params.get("skip_permissions", True)
+        label = params.get("label")
         resume_mode_str = params.get("resume_mode", "new")
         try:
             resume_mode = ResumeMode(resume_mode_str)
@@ -341,26 +348,36 @@ class IpcServer:
 
                 center = self._app.query_one(CenterPanel)
                 panel = await center.ensure_panel(worktree_path)
-                await panel.spawn_agent(
+                agent_id = await panel.spawn_agent(
                     skip_permissions=skip_permissions,
                     agent_provider=self._app._config.agent.provider,
                     resume_mode=resume_mode,
                     socket_path=self._socket_path,
                     instruction=instruction,
+                    label=label,
                 )
-                future.set_result(None)
+                state = self._app._get_agent_state(worktree_path, agent_id)
+                state.label = panel.agent_label(agent_id)
+                self._app._refresh_sidebar_agents(worktree_path)
+                future.set_result(agent_id)
             except Exception as e:
                 future.set_exception(e)
 
         self._app.call_later(_do_spawn)
 
-        await asyncio.wait_for(future, timeout=_TEXTUAL_OP_TIMEOUT)
-        return _ok(request_id, {"worktree_path": worktree_path, "status": "spawned"})
+        agent_id = await asyncio.wait_for(future, timeout=_TEXTUAL_OP_TIMEOUT)
+        return _ok(
+            request_id,
+            {"worktree_path": worktree_path, "agent_id": agent_id, "status": "spawned"},
+        )
 
     async def handle_stop_agent(
         self, request_id: str, params: dict
     ) -> dict:
-        """Stop the agent in a worktree. Params: worktree_path."""
+        """Stop an agent in a worktree. Params: worktree_path, agent_id (optional).
+
+        ``agent_id`` may be omitted when the worktree has exactly one agent.
+        """
         worktree_path = params.get("worktree_path", "")
         if not worktree_path:
             raise ValueError("worktree_path is required")
@@ -369,22 +386,18 @@ class IpcServer:
 
         center = self._app.query_one(CenterPanel)
         panel = center.get_panel(worktree_path)
-        if panel is None or not panel.has_agent:
+        if panel is None or not panel.agent_ids:
             raise ValueError("No running agent in this worktree")
+
+        agent_id = self._resolve_agent_id(panel.agent_ids, params.get("agent_id"))
 
         future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
 
         async def _do_stop() -> None:
             try:
-                from lazyagent.widgets.worktree_list import WorktreeList
-
-                state = self._app._get_agent_state(worktree_path)
-                state.status = AgentStatus.NO_AGENT
-                state.last_output_time = None
-                self._app.query_one(WorktreeList).update_agent_state(
-                    worktree_path, state
-                )
-                await panel.cleanup_agent()
+                self._app._drop_agent_state(worktree_path, agent_id)
+                self._app._refresh_sidebar_agents(worktree_path)
+                await panel.cleanup_agent(agent_id)
                 future.set_result(None)
             except Exception as e:
                 future.set_exception(e)
@@ -392,26 +405,34 @@ class IpcServer:
         self._app.call_later(_do_stop)
 
         await asyncio.wait_for(future, timeout=_TEXTUAL_OP_TIMEOUT)
-        return _ok(request_id, {"worktree_path": worktree_path, "status": "stopped"})
+        return _ok(
+            request_id,
+            {"worktree_path": worktree_path, "agent_id": agent_id, "status": "stopped"},
+        )
 
     async def handle_get_agent_status(
         self, request_id: str, params: dict
     ) -> dict:
-        """Get agent status for a worktree. Params: worktree_path."""
+        """Get agent status for a worktree. Params: worktree_path, agent_id
+        (optional). ``agent_id`` may be omitted when there is one agent."""
         worktree_path = params.get("worktree_path", "")
         if not worktree_path:
             raise ValueError("worktree_path is required")
 
-        state = self._app._agent_states.get(worktree_path)
-        if state is None:
+        bucket = self._agent_bucket(worktree_path)
+        if not bucket:
             return _ok(request_id, {
                 "worktree_path": worktree_path,
+                "agent_id": "",
                 "status": AgentStatus.NO_AGENT.value,
                 "detail": "",
             })
 
+        agent_id = self._resolve_agent_id(list(bucket.keys()), params.get("agent_id"))
+        state = bucket[agent_id]
         return _ok(request_id, {
             "worktree_path": worktree_path,
+            "agent_id": agent_id,
             "status": state.status.value,
             "confidence": state.confidence.value,
             "detail": state.detail,
@@ -420,7 +441,8 @@ class IpcServer:
     async def handle_read_agent_output(
         self, request_id: str, params: dict
     ) -> dict:
-        """Read recent terminal output from an agent. Params: worktree_path, lines (optional)."""
+        """Read recent terminal output from an agent. Params: worktree_path,
+        agent_id (optional), lines (optional)."""
         worktree_path = params.get("worktree_path", "")
         num_lines = params.get("lines", 50)
         if not worktree_path:
@@ -430,10 +452,13 @@ class IpcServer:
 
         center = self._app.query_one(CenterPanel)
         panel = center.get_panel(worktree_path)
-        if panel is None or panel.agent_terminal is None:
+        if panel is None or not panel.agent_ids:
             raise ValueError("No agent terminal in this worktree")
 
-        terminal = panel.agent_terminal
+        agent_id = self._resolve_agent_id(panel.agent_ids, params.get("agent_id"))
+        terminal = panel.get_agent(agent_id)
+        if terminal is None:
+            raise ValueError("No agent terminal in this worktree")
         screen = terminal._screen
         total_lines = len(screen.scrollback) + screen.lines
 
@@ -467,6 +492,7 @@ class IpcServer:
 
         return _ok(request_id, {
             "worktree_path": worktree_path,
+            "agent_id": agent_id,
             "lines": collected,
             "total_lines": total_lines,
         })
@@ -474,7 +500,8 @@ class IpcServer:
     async def handle_send_agent_input(
         self, request_id: str, params: dict
     ) -> dict:
-        """Send text input to a running agent's terminal. Params: worktree_path, text."""
+        """Send text input to a running agent's terminal. Params: worktree_path,
+        text, agent_id (optional)."""
         worktree_path = params.get("worktree_path", "")
         text = params.get("text", "")
         if not worktree_path:
@@ -486,10 +513,11 @@ class IpcServer:
 
         center = self._app.query_one(CenterPanel)
         panel = center.get_panel(worktree_path)
-        if panel is None or not panel.has_agent:
+        if panel is None or not panel.agent_ids:
             raise ValueError("No running agent in this worktree")
 
-        terminal = panel.agent_terminal
+        agent_id = self._resolve_agent_id(panel.agent_ids, params.get("agent_id"))
+        terminal = panel.get_agent(agent_id)
         if terminal is None or terminal.send_queue is None:
             raise ValueError("Agent terminal is not ready")
 
@@ -498,7 +526,28 @@ class IpcServer:
         # handler; LF would be interpreted as Shift+Enter (newline within
         # the prompt) by Claude Code and most line-editing TUIs.
         await terminal.send_queue.put(["stdin", text + "\r"])
-        return _ok(request_id, {"worktree_path": worktree_path, "status": "sent"})
+        return _ok(
+            request_id,
+            {"worktree_path": worktree_path, "agent_id": agent_id, "status": "sent"},
+        )
+
+    async def handle_list_agents(
+        self, request_id: str, params: dict
+    ) -> dict:
+        """List the agents in a worktree. Params: worktree_path.
+
+        Returns ``{worktree_path, agents: [{agent_id, label, status,
+        confidence, detail}]}``.
+        """
+        worktree_path = params.get("worktree_path", "")
+        if not worktree_path:
+            raise ValueError("worktree_path is required")
+
+        bucket = self._agent_bucket(worktree_path)
+        return _ok(request_id, {
+            "worktree_path": worktree_path,
+            "agents": self._agents_payload(bucket),
+        })
 
     # ------------------------------------------------------------------
     # Helpers
@@ -510,6 +559,50 @@ class IpcServer:
             if wt.path == path:
                 return wt
         return None
+
+    def _agent_bucket(self, worktree_path: str) -> dict[str, AgentState]:
+        """Agent-state map for a worktree (may be empty)."""
+        return self._app._agent_states.get(worktree_path, {})
+
+    @staticmethod
+    def _resolve_agent_id(
+        available: list[str], agent_id: str | None, *, what: str = "agent"
+    ) -> str:
+        """Resolve an optional agent id against the available ids.
+
+        Back-compatible rule: an explicit id must exist; if omitted and there
+        is exactly one agent, address it; otherwise fail with a list so the
+        caller disambiguates.
+        """
+        if agent_id:
+            if agent_id not in available:
+                raise ValueError(
+                    f"No {what} {agent_id!r} in this worktree. "
+                    f"Available: {available}"
+                )
+            return agent_id
+        if len(available) == 1:
+            return available[0]
+        if not available:
+            raise ValueError(f"No running {what} in this worktree")
+        raise ValueError(
+            f"Multiple agents in this worktree; specify agent_id. "
+            f"Available: {available}"
+        )
+
+    @staticmethod
+    def _agents_payload(bucket: dict[str, AgentState]) -> list[dict]:
+        """Serialise a worktree's agent states for IPC responses."""
+        return [
+            {
+                "agent_id": aid,
+                "label": st.label,
+                "status": st.status.value,
+                "confidence": st.confidence.value,
+                "detail": st.detail,
+            }
+            for aid, st in bucket.items()
+        ]
 
 
 async def start_ipc_server(app: LazyAgent) -> tuple[IpcServer, str]:

--- a/src/lazyagent/mcp_server.py
+++ b/src/lazyagent/mcp_server.py
@@ -253,10 +253,14 @@ async def spawn_agent(
     instruction: str | None = None,
     skip_permissions: bool = True,
     resume_mode: str = "new",
+    label: str | None = None,
 ) -> dict:
-    """Spawn a coding agent in a worktree.
+    """Spawn a NEW coding agent in a worktree.
 
-    Only one agent can run per worktree at a time.
+    A worktree can host multiple agents, each in its own tab. Every call to
+    this tool adds another agent and returns its ``agent_id``; use that id with
+    the other agent tools to address this specific agent. Omitting ``agent_id``
+    on those tools works only when the worktree has exactly one agent.
 
     Args:
         worktree_path: Absolute path of the worktree.
@@ -271,9 +275,10 @@ async def spawn_agent(
             session AND passes the instruction as a new turn — it does not
             replace the prior task. For a clean restart with new instructions,
             use the default ``resume_mode="new"``.
+        label: Optional human-facing tab label (defaults to "Agent N").
 
     Returns:
-        Object with worktree_path and status.
+        Object with worktree_path, agent_id, and status.
     """
     params: dict[str, Any] = {
         "worktree_path": worktree_path,
@@ -282,62 +287,93 @@ async def spawn_agent(
     }
     if instruction is not None:
         params["instruction"] = instruction
+    if label is not None:
+        params["label"] = label
     return await _get_client().call("spawn_agent", params)
 
 
 @mcp.tool()
-async def stop_agent(worktree_path: str) -> dict:
-    """Stop the running agent in a worktree.
+async def list_agents(worktree_path: str) -> dict:
+    """List the agents running in a worktree.
 
     Args:
         worktree_path: Absolute path of the worktree.
 
     Returns:
-        Object confirming the agent was stopped.
+        Object with worktree_path and an ``agents`` list; each entry has
+        agent_id, label, status, confidence, and detail.
     """
     return await _get_client().call(
-        "stop_agent",
+        "list_agents",
         {"worktree_path": worktree_path},
     )
 
 
 @mcp.tool()
-async def get_agent_status(worktree_path: str) -> dict:
-    """Get the current status of the agent in a worktree.
+async def stop_agent(worktree_path: str, agent_id: str | None = None) -> dict:
+    """Stop a running agent in a worktree.
 
     Args:
         worktree_path: Absolute path of the worktree.
+        agent_id: Which agent to stop. May be omitted when the worktree has
+            exactly one agent; required (else an error lists the choices) when
+            there are several.
 
     Returns:
-        Object with status, confidence, and detail fields.
+        Object confirming the agent was stopped (includes agent_id).
     """
-    return await _get_client().call(
-        "get_agent_status",
-        {"worktree_path": worktree_path},
-    )
+    params: dict[str, Any] = {"worktree_path": worktree_path}
+    if agent_id is not None:
+        params["agent_id"] = agent_id
+    return await _get_client().call("stop_agent", params)
 
 
 @mcp.tool()
-async def read_agent_output(worktree_path: str, lines: int = 50) -> dict:
-    """Read recent terminal output from the agent in a worktree.
+async def get_agent_status(worktree_path: str, agent_id: str | None = None) -> dict:
+    """Get the current status of an agent in a worktree.
+
+    Args:
+        worktree_path: Absolute path of the worktree.
+        agent_id: Which agent to query. May be omitted when the worktree has
+            exactly one agent; required when there are several.
+
+    Returns:
+        Object with agent_id, status, confidence, and detail fields.
+    """
+    params: dict[str, Any] = {"worktree_path": worktree_path}
+    if agent_id is not None:
+        params["agent_id"] = agent_id
+    return await _get_client().call("get_agent_status", params)
+
+
+@mcp.tool()
+async def read_agent_output(
+    worktree_path: str, lines: int = 50, agent_id: str | None = None
+) -> dict:
+    """Read recent terminal output from an agent in a worktree.
 
     Includes both scrollback history and the current live screen buffer.
 
     Args:
         worktree_path: Absolute path of the worktree.
         lines: Number of recent lines to return (default 50).
+        agent_id: Which agent to read. May be omitted when the worktree has
+            exactly one agent; required when there are several.
 
     Returns:
-        Object with lines (list of strings), total_lines count, and worktree_path.
+        Object with lines (list of strings), total_lines count, worktree_path,
+        and agent_id.
     """
-    return await _get_client().call(
-        "read_agent_output",
-        {"worktree_path": worktree_path, "lines": lines},
-    )
+    params: dict[str, Any] = {"worktree_path": worktree_path, "lines": lines}
+    if agent_id is not None:
+        params["agent_id"] = agent_id
+    return await _get_client().call("read_agent_output", params)
 
 
 @mcp.tool()
-async def send_agent_input(worktree_path: str, text: str) -> dict:
+async def send_agent_input(
+    worktree_path: str, text: str, agent_id: str | None = None
+) -> dict:
     """Send text input to a running agent's terminal.
 
     Use this to provide follow-up instructions, answer prompts, or approve
@@ -346,14 +382,16 @@ async def send_agent_input(worktree_path: str, text: str) -> dict:
     Args:
         worktree_path: Absolute path of the worktree.
         text: The text to send to the agent's stdin (a newline is appended automatically).
+        agent_id: Which agent to send to. May be omitted when the worktree has
+            exactly one agent; required when there are several.
 
     Returns:
-        Object confirming the input was sent.
+        Object confirming the input was sent (includes agent_id).
     """
-    return await _get_client().call(
-        "send_agent_input",
-        {"worktree_path": worktree_path, "text": text},
-    )
+    params: dict[str, Any] = {"worktree_path": worktree_path, "text": text}
+    if agent_id is not None:
+        params["agent_id"] = agent_id
+    return await _get_client().call("send_agent_input", params)
 
 
 if __name__ == "__main__":

--- a/src/lazyagent/messages.py
+++ b/src/lazyagent/messages.py
@@ -6,7 +6,11 @@ from lazyagent.models import AgentStatus, LifecycleConfidence
 
 
 class AgentStatusChanged(Message):
-    """Agent status transition (RUNNING, WAITING, POSSIBLY_HANGED)."""
+    """Agent status transition (RUNNING, WAITING, POSSIBLY_HANGED).
+
+    ``agent_id`` identifies which agent within the worktree changed; ``""``
+    means the single/legacy agent (e.g. the orchestrator).
+    """
 
     def __init__(
         self,
@@ -14,17 +18,20 @@ class AgentStatusChanged(Message):
         status: AgentStatus,
         confidence: LifecycleConfidence = LifecycleConfidence.LOW,
         detail: str = "",
+        agent_id: str = "",
     ) -> None:
         super().__init__()
         self.worktree_path = worktree_path
         self.status = status
         self.confidence = confidence
         self.detail = detail
+        self.agent_id = agent_id
 
 
 class AgentExited(Message):
     """Claude process disconnected from the pty."""
 
-    def __init__(self, worktree_path: str) -> None:
+    def __init__(self, worktree_path: str, agent_id: str = "") -> None:
         super().__init__()
         self.worktree_path = worktree_path
+        self.agent_id = agent_id

--- a/src/lazyagent/models.py
+++ b/src/lazyagent/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 
@@ -94,6 +95,49 @@ class AgentState:
     confidence: LifecycleConfidence = LifecycleConfidence.LOW
     detail: str = ""
     last_output_time: float | None = None  # time.monotonic()
+    agent_id: str = ""   # "" = legacy/primary (single-agent, e.g. orchestrator)
+    label: str = ""      # human-facing tab label (e.g. "Agent 1")
+
+
+# Priority order for rolling up several per-agent statuses into one summary
+# status for a worktree. Earlier = "needs more attention", so it wins the
+# roll-up. Used by both the sidebar summary and the IPC scalar agent_status.
+_STATUS_PRIORITY: tuple[AgentStatus, ...] = (
+    AgentStatus.WAITING_FOR_APPROVAL,
+    AgentStatus.WAITING_FOR_USER,
+    AgentStatus.WAITING,
+    AgentStatus.POSSIBLY_HANGED,
+    AgentStatus.FAILED,
+    AgentStatus.RUNNING,
+    AgentStatus.INTERRUPTED,
+    AgentStatus.COMPLETED,
+    AgentStatus.NO_AGENT,
+)
+
+
+def _status_rank(status: AgentStatus) -> int:
+    try:
+        return _STATUS_PRIORITY.index(status)
+    except ValueError:
+        return len(_STATUS_PRIORITY)
+
+
+def rollup_status(statuses: Iterable[AgentStatus]) -> AgentStatus:
+    """Collapse several agent statuses into a single summary status.
+
+    Returns the highest-priority status (see ``_STATUS_PRIORITY``), or
+    ``NO_AGENT`` when there are no agents.
+    """
+    ranked = sorted(statuses, key=_status_rank)
+    return ranked[0] if ranked else AgentStatus.NO_AGENT
+
+
+def dominant_state(states: Iterable[AgentState]) -> AgentState | None:
+    """Return the agent state that wins the roll-up, or None if empty."""
+    items = list(states)
+    if not items:
+        return None
+    return min(items, key=lambda s: _status_rank(s.status))
 
 
 @dataclass

--- a/src/lazyagent/widgets/center_panel.py
+++ b/src/lazyagent/widgets/center_panel.py
@@ -25,6 +25,19 @@ def _panel_id(worktree_path: str) -> str:
     return "wp-" + hashlib.md5(worktree_path.encode()).hexdigest()[:8]
 
 
+_SPAWN_HINT = "Press [bold]s[/bold] or [bold]Ctrl+J[/bold] to spawn agent"
+_PLACEHOLDER_TAB_ID = "agent-placeholder-tab"
+_DIFF_TAB_ID = "diff-tab"
+
+
+def _agent_tab_id(agent_id: str) -> str:
+    return f"agent-tab-{agent_id}"
+
+
+def _agent_terminal_id(agent_id: str) -> str:
+    return f"agent-terminal-{agent_id}"
+
+
 class GitInfoBar(Static):
     """Thin bar showing git status for the current worktree."""
 
@@ -89,10 +102,7 @@ class WorktreePanel(Container):
         border: solid $accent;
         border-title-color: $accent;
     }}
-    #agent-tab {{
-        height: 1fr;
-    }}
-    #diff-tab {{
+    #agent-tabs TabPane {{
         height: 1fr;
     }}
     #diff-scroll {{
@@ -135,17 +145,18 @@ class WorktreePanel(Container):
     def __init__(self, worktree_path: str, **kwargs) -> None:
         super().__init__(**kwargs)
         self.worktree_path = worktree_path
-        self._agent_terminal: MonitoredTerminal | None = None
+        # agent_id -> terminal. Ordered by spawn order; each agent gets its
+        # own TabPane to the left of the permanent Diff tab.
+        self._agents: dict[str, MonitoredTerminal] = {}
+        self._labels: dict[str, str] = {}
+        self._agent_counter = 0
 
     def compose(self):
         yield GitInfoBar(id="git-info-bar")
         with TabbedContent(id="agent-tabs"):
-            with TabPane("Agent", id="agent-tab"):
-                yield Static(
-                    "Press [bold]s[/bold] or [bold]Ctrl+J[/bold] to spawn agent",
-                    id="agent-placeholder",
-                )
-            with TabPane("Diff", id="diff-tab"):
+            with TabPane("Agent", id=_PLACEHOLDER_TAB_ID):
+                yield Static(_SPAWN_HINT, id="agent-placeholder")
+            with TabPane("Diff", id=_DIFF_TAB_ID):
                 with VerticalScroll(id="diff-scroll"):
                     yield Static(
                         Text("No changes"),
@@ -209,34 +220,98 @@ class WorktreePanel(Container):
         except Exception:
             pass
 
+    # ------------------------------------------------------------------
+    # Multi-agent accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def agent_ids(self) -> list[str]:
+        """Agent ids in spawn order."""
+        return list(self._agents.keys())
+
+    def get_agent(self, agent_id: str) -> MonitoredTerminal | None:
+        """Return the terminal for a specific agent, or None."""
+        return self._agents.get(agent_id)
+
+    def agent_label(self, agent_id: str) -> str:
+        """Return the human-facing tab label for an agent."""
+        return self._labels.get(agent_id, "")
+
+    @property
+    def active_agent_id(self) -> str | None:
+        """The agent whose tab is currently active, the sole agent, or None.
+
+        Falls back to the only agent when the active tab is Diff/placeholder
+        but exactly one agent exists, so ``x``/focus behave intuitively.
+        """
+        try:
+            tabs = self.query_one("#agent-tabs", TabbedContent)
+            active = tabs.active or ""
+        except Exception:
+            active = ""
+        prefix = _agent_tab_id("")
+        if active.startswith(prefix):
+            aid = active[len(prefix):]
+            if aid in self._agents:
+                return aid
+        if len(self._agents) == 1:
+            return next(iter(self._agents))
+        return None
+
     @property
     def agent_terminal(self) -> MonitoredTerminal | None:
-        return self._agent_terminal
+        """Back-compat: the active agent's terminal (or the sole agent)."""
+        aid = self.active_agent_id
+        return self._agents.get(aid) if aid else None
 
     @property
     def has_agent(self) -> bool:
-        return (
-            self._agent_terminal is not None
-            and self._agent_terminal.emulator is not None
-        )
+        """True if any spawned agent has a live pty."""
+        return any(t.emulator is not None for t in self._agents.values())
 
-    async def cleanup_agent(self) -> None:
-        """Remove the agent terminal widget and restore the placeholder."""
-        if self._agent_terminal is not None:
-            self._agent_terminal.stop()
-            await self._agent_terminal.remove()
-            self._agent_terminal = None
+    def _new_agent_id(self) -> str:
+        self._agent_counter += 1
+        return f"a{self._agent_counter}"
 
-        pane = self.query_one("#agent-tab", TabPane)
+    async def _ensure_placeholder_tab(self) -> None:
+        """Re-add the placeholder tab when no agents remain."""
+        tabs = self.query_one("#agent-tabs", TabbedContent)
         try:
-            pane.query_one("#agent-placeholder")
+            self.query_one(f"#{_PLACEHOLDER_TAB_ID}", TabPane)
+            return  # already present
         except Exception:
-            pane.mount(
-                Static(
-                    "Press [bold]s[/bold] or [bold]Ctrl+J[/bold] to spawn agent",
-                    id="agent-placeholder",
-                )
-            )
+            pass
+        pane = TabPane(
+            "Agent",
+            Static(_SPAWN_HINT, id="agent-placeholder"),
+            id=_PLACEHOLDER_TAB_ID,
+        )
+        await tabs.add_pane(pane, before=_DIFF_TAB_ID)
+        tabs.active = _PLACEHOLDER_TAB_ID
+
+    async def cleanup_agent(self, agent_id: str | None = None) -> None:
+        """Remove one agent's tab (or all), restoring the placeholder if empty.
+
+        ``agent_id=None`` cleans up every agent — used on worktree teardown.
+        """
+        tabs = self.query_one("#agent-tabs", TabbedContent)
+        targets = (
+            list(self._agents.keys())
+            if agent_id is None
+            else [agent_id] if agent_id in self._agents else []
+        )
+        for aid in targets:
+            terminal = self._agents.pop(aid, None)
+            self._labels.pop(aid, None)
+            if terminal is not None:
+                terminal.stop()
+            try:
+                await tabs.remove_pane(_agent_tab_id(aid))
+            except Exception:
+                pass
+
+        if not self._agents:
+            await self._ensure_placeholder_tab()
 
     async def spawn_agent(
         self,
@@ -245,22 +320,20 @@ class WorktreePanel(Container):
         resume_mode: ResumeMode = ResumeMode.NEW,
         socket_path: str | None = None,
         instruction: str | None = None,
-    ) -> None:
-        """Spawn the configured coding agent process in the Agent pane."""
-        pane = self.query_one("#agent-tab", TabPane)
+        label: str | None = None,
+    ) -> str:
+        """Spawn a new coding agent in its own tab. Returns the new agent id."""
+        tabs = self.query_one("#agent-tabs", TabbedContent)
 
-        # Remove previous terminal or placeholder (await to ensure DOM is clean
-        # before mounting the new widget with the same ID).
-        if self._agent_terminal is not None:
-            self._agent_terminal.stop()
-            await self._agent_terminal.remove()
-            self._agent_terminal = None
-
+        # First agent: drop the "press s to spawn" placeholder tab.
         try:
-            placeholder = self.query_one("#agent-placeholder", Static)
-            await placeholder.remove()
+            await tabs.remove_pane(_PLACEHOLDER_TAB_ID)
         except Exception:
             pass
+
+        agent_id = self._new_agent_id()
+        tab_label = label or f"Agent {agent_id[1:]}"
+        self._labels[agent_id] = tab_label
 
         provider = get_agent_provider(agent_provider)
         runtime_context = provider.build_runtime_context(
@@ -278,14 +351,18 @@ class WorktreePanel(Container):
             command=command,
             worktree_path=self.worktree_path,
             observer=provider.create_observer_from_context(runtime_context),
-            id="agent-terminal",
+            agent_id=agent_id,
+            id=_agent_terminal_id(agent_id),
         )
-        self._agent_terminal = terminal
-        pane.mount(terminal)
+        self._agents[agent_id] = terminal
+        pane = TabPane(tab_label, terminal, id=_agent_tab_id(agent_id))
+        await tabs.add_pane(pane, before=_DIFF_TAB_ID)
         terminal.start()
 
-        # Focus the terminal so the user can type immediately
+        # Make the new agent's tab active and focus its terminal.
+        tabs.active = _agent_tab_id(agent_id)
         terminal.focus()
+        return agent_id
 
 
 class CenterPanel(Container):

--- a/src/lazyagent/widgets/help_modal.py
+++ b/src/lazyagent/widgets/help_modal.py
@@ -16,8 +16,9 @@ _HELP_TEXT = """\
   [bold]Ctrl+L[/bold]          Focus terminal pane
 
 [bold cyan]Agents[/bold cyan]
-  [bold]s[/bold]               Spawn or resume agent in selected worktree
-  [bold]x[/bold]               Stop agent in selected worktree
+  [bold]s[/bold]               Spawn a new agent (adds a tab; multiple per worktree)
+  [bold]x[/bold]               Stop the active agent tab
+  [bold]Ctrl+J[/bold]          Focus the active agent tab
 
 [bold cyan]Worktrees[/bold cyan]
   [bold]c[/bold]               Create new worktree

--- a/src/lazyagent/widgets/help_modal.py
+++ b/src/lazyagent/widgets/help_modal.py
@@ -19,6 +19,8 @@ _HELP_TEXT = """\
   [bold]s[/bold]               Spawn a new agent (adds a tab; multiple per worktree)
   [bold]x[/bold]               Stop the active agent tab
   [bold]Ctrl+J[/bold]          Focus the active agent tab
+  [bold]Ctrl+][/bold]          Next agent tab
+  [bold]Ctrl+\\[/bold]          Previous agent tab
 
 [bold cyan]Worktrees[/bold cyan]
   [bold]c[/bold]               Create new worktree

--- a/src/lazyagent/widgets/monitored_terminal.py
+++ b/src/lazyagent/widgets/monitored_terminal.py
@@ -29,10 +29,12 @@ class MonitoredTerminal(ScrollableTerminal):
         command: str,
         worktree_path: str,
         observer: AgentObserver | None = None,
+        agent_id: str = "",
         **kwargs,
     ) -> None:
         super().__init__(command=command, **kwargs)
         self.worktree_path = worktree_path
+        self.agent_id = agent_id
         self._status = AgentStatus.NO_AGENT
         self._detail = ""
         self._last_output_time: float | None = None
@@ -66,6 +68,7 @@ class MonitoredTerminal(ScrollableTerminal):
                         new_status,
                         confidence=confidence,
                         detail=detail,
+                        agent_id=self.agent_id,
                     )
                 )
 
@@ -118,7 +121,7 @@ class MonitoredTerminal(ScrollableTerminal):
         self._observer.cleanup()
         self._status = AgentStatus.NO_AGENT
         if not self._stopped:
-            self.post_message(AgentExited(self.worktree_path))
+            self.post_message(AgentExited(self.worktree_path, agent_id=self.agent_id))
 
     def check_hang(self) -> None:
         """Called periodically by the app timer. Posts POSSIBLY_HANGED if stale."""

--- a/src/lazyagent/widgets/orchestrator_panel.py
+++ b/src/lazyagent/widgets/orchestrator_panel.py
@@ -43,6 +43,14 @@ class OrchestratorPanel(Container):
     def agent_terminal(self) -> MonitoredTerminal | None:
         return self._agent_terminal
 
+    def get_agent(self, agent_id: str = "") -> MonitoredTerminal | None:
+        """The orchestrator is single-agent; ``agent_id`` is ignored."""
+        return self._agent_terminal
+
+    @property
+    def agent_ids(self) -> list[str]:
+        return [""] if self._agent_terminal is not None else []
+
     @property
     def has_agent(self) -> bool:
         return (
@@ -50,7 +58,7 @@ class OrchestratorPanel(Container):
             and self._agent_terminal.emulator is not None
         )
 
-    async def cleanup_agent(self) -> None:
+    async def cleanup_agent(self, agent_id: str | None = None) -> None:
         """Remove the agent terminal and restore the placeholder."""
         if self._agent_terminal is not None:
             self._agent_terminal.stop()

--- a/src/lazyagent/widgets/worktree_list.py
+++ b/src/lazyagent/widgets/worktree_list.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from textual.binding import Binding
 from textual.widgets import ListItem, ListView, Static
 
-from lazyagent.models import AgentState, AgentStatus, GitStatus, LifecycleConfidence, WorktreeInfo
+from lazyagent.models import (
+    AgentState,
+    AgentStatus,
+    GitStatus,
+    LifecycleConfidence,
+    WorktreeInfo,
+    dominant_state,
+)
 from lazyagent.widgets.orchestrator_panel import ORCHESTRATOR_KEY
 
 
@@ -40,6 +47,22 @@ def format_agent_status(state: AgentState) -> str:
         res += f" [dim]({state.detail})[/dim]"
 
     return res or "[dim]---[/dim]"
+
+
+def format_agents_status(states: dict[str, AgentState]) -> str:
+    """Format a worktree's agents into a single roll-up status string.
+
+    No agents -> ``---``. One agent -> the single-agent format. Several ->
+    the highest-priority agent's status plus a ``(+N)`` overflow marker.
+    """
+    active = list(states.values())
+    if not active:
+        return "[dim]---[/dim]"
+    if len(active) == 1:
+        return format_agent_status(active[0])
+    dominant = dominant_state(active)
+    base = format_agent_status(dominant) if dominant else "[dim]---[/dim]"
+    return f"{base} [dim](+{len(active) - 1})[/dim]"
 
 
 class OrchestratorListItem(ListItem):
@@ -96,10 +119,14 @@ class WorktreeListItem(ListItem):
     }
     """
 
-    def __init__(self, worktree: WorktreeInfo, agent_state: AgentState | None = None) -> None:
+    def __init__(
+        self,
+        worktree: WorktreeInfo,
+        agent_states: dict[str, AgentState] | None = None,
+    ) -> None:
         super().__init__()
         self.worktree = worktree
-        self._agent_state = agent_state or AgentState()
+        self._agent_states: dict[str, AgentState] = dict(agent_states or {})
         self._git_status: GitStatus | None = None
         if worktree.is_main:
             self.add_class("--main")
@@ -110,7 +137,7 @@ class WorktreeListItem(ListItem):
     def _build_label(self) -> str:
         label = self.worktree.display_label
         branch = self.worktree.display_branch
-        status = format_agent_status(self._agent_state)
+        status = format_agents_status(self._agent_states)
         git = self._git_status_line()
         return f"[bold]{label}[/bold]\n{branch}\n{status}\n{git}"
 
@@ -130,9 +157,9 @@ class WorktreeListItem(ListItem):
                 parts.append(f"[red]\u2193{gs.behind}[/red]")
         return " ".join(parts)
 
-    def update_agent_state(self, state: AgentState) -> None:
-        """Re-render the label with updated agent state."""
-        self._agent_state = state
+    def update_agent_states(self, states: dict[str, AgentState]) -> None:
+        """Re-render the label with the worktree's full set of agent states."""
+        self._agent_states = dict(states)
         try:
             label_widget = self.query_one("#wt-label", Static)
             label_widget.update(self._build_label())
@@ -172,18 +199,28 @@ class WorktreeList(ListView):
     def on_mount(self) -> None:
         self.border_title = "Ctrl+K Sidebar"
 
-    def set_worktrees(self, worktrees: list[WorktreeInfo], agent_states: dict[str, AgentState] | None = None) -> None:
-        """Replace the list contents with the given worktrees, restoring agent state if provided."""
+    def set_worktrees(
+        self,
+        worktrees: list[WorktreeInfo],
+        agent_states: dict[str, dict[str, AgentState]] | None = None,
+    ) -> None:
+        """Replace the list contents, restoring per-agent state if provided.
+
+        ``agent_states`` is the app's two-level registry: outer key is a
+        worktree path (or ``ORCHESTRATOR_KEY``), inner maps agent id to state.
+        """
         self.clear()
         agent_states = agent_states or {}
-        self.append(OrchestratorListItem(agent_state=agent_states.get(ORCHESTRATOR_KEY)))
+        orch_states = agent_states.get(ORCHESTRATOR_KEY, {})
+        orch_state = dominant_state(orch_states.values()) if orch_states else None
+        self.append(OrchestratorListItem(agent_state=orch_state))
         for wt in worktrees:
-            state = agent_states.get(wt.path)
-            self.append(WorktreeListItem(wt, agent_state=state))
+            self.append(WorktreeListItem(wt, agent_states=agent_states.get(wt.path, {})))
 
-    def update_agent_state(self, key: str, state: AgentState) -> None:
-        """Update the sidebar item for the given key (worktree path or ORCHESTRATOR_KEY)."""
+    def update_agent_states(self, key: str, states: dict[str, AgentState]) -> None:
+        """Update the sidebar item for a worktree path or ORCHESTRATOR_KEY."""
         if key == ORCHESTRATOR_KEY:
+            state = dominant_state(states.values()) or AgentState()
             for child in self.children:
                 if isinstance(child, OrchestratorListItem):
                     child.update_agent_state(state)
@@ -191,7 +228,7 @@ class WorktreeList(ListView):
         else:
             for child in self.children:
                 if isinstance(child, WorktreeListItem) and child.worktree.path == key:
-                    child.update_agent_state(state)
+                    child.update_agent_states(states)
                     break
 
     def update_all_git_statuses(self, statuses: dict[str, GitStatus]) -> None:

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -185,7 +185,9 @@ def test_do_remove_worktree_injects_custom_command_with_repo_cd_prefix() -> None
 def test_remove_worktree_is_blocked_for_active_agents(status: AgentStatus) -> None:
     app = LazyAgent(repo_path="/repo")
     app._get_selected_worktree = lambda: FEATURE_WORKTREE
-    app._get_agent_state = lambda path: AgentState(status=status)
+    app._agent_states = {
+        FEATURE_WORKTREE.path: {"a1": AgentState(status=status, agent_id="a1")}
+    }
     app.notify = MagicMock()
     app.push_screen = MagicMock()
 

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -21,7 +21,11 @@ def _make_app(worktrees=None, agent_states=None, git_statuses=None):
     app._repo_root = "/tmp/repo"
     app._config.agent.provider = "claude"
     app._config.has_custom_create = False
-    app._get_agent_state = MagicMock(side_effect=lambda p: app._agent_states.setdefault(p, AgentState()))
+    app._get_agent_state = MagicMock(
+        side_effect=lambda p, aid="": app._agent_states.setdefault(p, {}).setdefault(
+            aid, AgentState(agent_id=aid)
+        )
+    )
     return app
 
 
@@ -46,7 +50,7 @@ class TestListWorktrees:
 
         app = _make_app(
             worktrees=[wt, wt2],
-            agent_states={"/tmp/repo-feat": state},
+            agent_states={"/tmp/repo-feat": {"a1": state}},
             git_statuses={"/tmp/repo": git_st},
         )
         server = IpcServer(app, "/tmp/test.sock")
@@ -59,11 +63,21 @@ class TestListWorktrees:
         assert data[0]["path"] == "/tmp/repo"
         assert data[0]["is_main"] is True
         assert data[0]["agent_status"] == "no_agent"
+        assert data[0]["agents"] == []
         assert data[0]["git_status"]["dirty_count"] == 2
 
-        # Feature worktree
+        # Feature worktree — scalar roll-up plus per-agent detail
         assert data[1]["path"] == "/tmp/repo-feat"
         assert data[1]["agent_status"] == "running"
+        assert data[1]["agents"] == [
+            {
+                "agent_id": "a1",
+                "label": "",
+                "status": "running",
+                "confidence": "low",
+                "detail": "",
+            }
+        ]
 
 
 class TestCreateWorktree:
@@ -182,7 +196,7 @@ class TestRemoveWorktree:
     async def test_rejects_worktree_with_running_agent(self):
         wt = _make_worktree("/tmp/repo-feat", "feat", is_main=False)
         state = AgentState(status=AgentStatus.RUNNING)
-        app = _make_app(worktrees=[wt], agent_states={"/tmp/repo-feat": state})
+        app = _make_app(worktrees=[wt], agent_states={"/tmp/repo-feat": {"a1": state}})
         server = IpcServer(app, "/tmp/test.sock")
 
         result = await server._dispatch("req-1", "remove_worktree", {"worktree_path": "/tmp/repo-feat"})
@@ -235,15 +249,32 @@ class TestSpawnAgent:
         assert "error" in result
 
     @pytest.mark.asyncio
-    async def test_rejects_duplicate_spawn(self):
+    async def test_does_not_reject_when_agent_already_running(self):
+        """Duplicate spawn is now allowed — a second agent is added.
+
+        The guard that used to reject a running worktree is gone, so the
+        handler proceeds past validation into the Textual-thread spawn. We
+        stub call_later (so the UI work is never scheduled) and wait_for (so
+        it resolves to the new agent id), and assert no "already running"
+        validation error.
+        """
         wt = _make_worktree("/tmp/repo-feat", "feat", is_main=False)
-        state = AgentState(status=AgentStatus.RUNNING)
-        app = _make_app(worktrees=[wt], agent_states={"/tmp/repo-feat": state})
+        state = AgentState(status=AgentStatus.RUNNING, agent_id="a1")
+        app = _make_app(
+            worktrees=[wt], agent_states={"/tmp/repo-feat": {"a1": state}}
+        )
+        app.call_later = MagicMock()
         server = IpcServer(app, "/tmp/test.sock")
 
-        result = await server._dispatch("req-1", "spawn_agent", {"worktree_path": "/tmp/repo-feat"})
-        assert "error" in result
-        assert "already running" in result["error"]["message"]
+        # asyncio.wait_for is async, so patch() auto-uses an AsyncMock.
+        with patch("asyncio.wait_for", return_value="a2"):
+            result = await server._dispatch(
+                "req-1", "spawn_agent", {"worktree_path": "/tmp/repo-feat"}
+            )
+
+        assert "result" in result, result
+        assert result["result"]["agent_id"] == "a2"
+        assert app.call_later.called
 
 
 class TestGetAgentStatus:
@@ -261,14 +292,94 @@ class TestGetAgentStatus:
             status=AgentStatus.WAITING_FOR_USER,
             confidence=LifecycleConfidence.HIGH,
             detail="needs input",
+            agent_id="a1",
         )
-        app = _make_app(agent_states={"/tmp/repo": state})
+        app = _make_app(agent_states={"/tmp/repo": {"a1": state}})
         server = IpcServer(app, "/tmp/test.sock")
 
         result = await server._dispatch("req-1", "get_agent_status", {"worktree_path": "/tmp/repo"})
         assert result["result"]["status"] == "waiting_for_user"
         assert result["result"]["confidence"] == "high"
         assert result["result"]["detail"] == "needs input"
+        assert result["result"]["agent_id"] == "a1"
+
+    @pytest.mark.asyncio
+    async def test_requires_agent_id_when_multiple(self):
+        app = _make_app(
+            agent_states={
+                "/tmp/repo": {
+                    "a1": AgentState(status=AgentStatus.RUNNING, agent_id="a1"),
+                    "a2": AgentState(status=AgentStatus.RUNNING, agent_id="a2"),
+                }
+            }
+        )
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch(
+            "req-1", "get_agent_status", {"worktree_path": "/tmp/repo"}
+        )
+        assert "error" in result
+        assert "specify agent_id" in result["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_selects_specific_agent_when_multiple(self):
+        app = _make_app(
+            agent_states={
+                "/tmp/repo": {
+                    "a1": AgentState(status=AgentStatus.RUNNING, agent_id="a1"),
+                    "a2": AgentState(
+                        status=AgentStatus.WAITING_FOR_USER, agent_id="a2"
+                    ),
+                }
+            }
+        )
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch(
+            "req-1",
+            "get_agent_status",
+            {"worktree_path": "/tmp/repo", "agent_id": "a2"},
+        )
+        assert result["result"]["agent_id"] == "a2"
+        assert result["result"]["status"] == "waiting_for_user"
+
+
+class TestListAgents:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_agents(self):
+        app = _make_app()
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch(
+            "req-1", "list_agents", {"worktree_path": "/tmp/repo"}
+        )
+        assert result["result"] == {"worktree_path": "/tmp/repo", "agents": []}
+
+    @pytest.mark.asyncio
+    async def test_lists_agents(self):
+        app = _make_app(
+            agent_states={
+                "/tmp/repo": {
+                    "a1": AgentState(
+                        status=AgentStatus.RUNNING, agent_id="a1", label="Agent 1"
+                    ),
+                    "a2": AgentState(
+                        status=AgentStatus.WAITING_FOR_USER,
+                        agent_id="a2",
+                        label="Agent 2",
+                    ),
+                }
+            }
+        )
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch(
+            "req-1", "list_agents", {"worktree_path": "/tmp/repo"}
+        )
+        agents = result["result"]["agents"]
+        assert [a["agent_id"] for a in agents] == ["a1", "a2"]
+        assert agents[1]["label"] == "Agent 2"
+        assert agents[1]["status"] == "waiting_for_user"
 
 
 class TestReadAgentOutput:

--- a/tests/test_monitored_terminal.py
+++ b/tests/test_monitored_terminal.py
@@ -22,6 +22,7 @@ def _make_terminal() -> MonitoredTerminal:
     """Create a MonitoredTerminal without starting the emulator."""
     terminal = MonitoredTerminal.__new__(MonitoredTerminal)
     terminal.worktree_path = WT_PATH
+    terminal.agent_id = ""
     terminal._status = AgentStatus.NO_AGENT
     terminal._detail = ""
     terminal._last_output_time = None

--- a/tests/test_multi_agent_panel.py
+++ b/tests/test_multi_agent_panel.py
@@ -206,6 +206,61 @@ async def test_spawn_then_stop_via_app_action(patched):
         assert panel.agent_ids == ["a1"]
 
 
+async def _select_feature(app, pilot):
+    """Highlight the feature worktree and return its panel."""
+    from lazyagent.widgets.worktree_list import WorktreeListItem
+
+    wt_list = app.query_one(WorktreeList)
+    item = [c for c in wt_list.children if isinstance(c, WorktreeListItem)][1]
+    wt_list.index = 2  # orchestrator(0) + main(1) + feature(2)
+    await app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, item))
+    await pilot.pause()
+    return app.query_one(CenterPanel).get_panel(FEATURE_WORKTREE.path)
+
+
+@pytest.mark.asyncio
+async def test_cycle_agents_wraps_both_directions(patched):
+    app = LazyAgent(repo_path="/repo")
+    async with app.run_test() as pilot:
+        panel = await _select_feature(app, pilot)
+        await panel.spawn_agent()  # a1
+        await panel.spawn_agent()  # a2
+        await panel.spawn_agent()  # a3 (active)
+        await pilot.pause()
+
+        assert panel.active_agent_id == "a3"
+
+        app.action_next_agent()  # wraps a3 -> a1
+        await pilot.pause()
+        assert panel.active_agent_id == "a1"
+
+        app.action_next_agent()  # a1 -> a2
+        await pilot.pause()
+        assert panel.active_agent_id == "a2"
+
+        app.action_prev_agent()  # a2 -> a1
+        await pilot.pause()
+        assert panel.active_agent_id == "a1"
+
+        app.action_prev_agent()  # wraps a1 -> a3
+        await pilot.pause()
+        assert panel.active_agent_id == "a3"
+
+
+@pytest.mark.asyncio
+async def test_cycle_agents_noop_with_single_agent(patched):
+    app = LazyAgent(repo_path="/repo")
+    async with app.run_test() as pilot:
+        panel = await _select_feature(app, pilot)
+        await panel.spawn_agent()  # a1
+        await pilot.pause()
+
+        app.action_next_agent()
+        app.action_prev_agent()
+        await pilot.pause()
+        assert panel.active_agent_id == "a1"
+
+
 # --- Pure roll-up formatting ---
 
 

--- a/tests/test_multi_agent_panel.py
+++ b/tests/test_multi_agent_panel.py
@@ -1,0 +1,231 @@
+"""Tests for multiple agents per worktree (WorktreePanel + sidebar roll-up)."""
+from __future__ import annotations
+
+import pytest
+from textual.widgets import TabbedContent, TabPane
+
+from lazyagent.app import LazyAgent
+from lazyagent.config import Config
+from lazyagent.models import AgentState, AgentStatus
+from lazyagent.widgets.center_panel import (
+    CenterPanel,
+    WorktreePanel,
+    _DIFF_TAB_ID,
+    _PLACEHOLDER_TAB_ID,
+)
+from lazyagent.widgets.monitored_terminal import MonitoredTerminal
+from lazyagent.widgets.worktree_list import format_agents_status
+from lazyagent.models import WorktreeInfo, GitStatus
+from lazyagent.widgets.worktree_list import WorktreeList
+
+
+MAIN_WORKTREE = WorktreeInfo(
+    path="/repo", head="a" * 40, branch="main", is_main=True, is_bare=False
+)
+FEATURE_WORKTREE = WorktreeInfo(
+    path="/repo-feature",
+    head="b" * 40,
+    branch="feature/demo",
+    is_main=False,
+    is_bare=False,
+)
+WORKTREES = [MAIN_WORKTREE, FEATURE_WORKTREE]
+
+
+class DummyWorktreeManager:
+    def __init__(self, repo_path):
+        from pathlib import Path
+
+        self.repo_path = Path(repo_path)
+
+    def list(self):
+        return WORKTREES
+
+    def get_all_git_statuses(self, worktrees):
+        return {wt.path: GitStatus() for wt in worktrees}
+
+    @staticmethod
+    def get_diff(worktree_path):
+        return ""
+
+    @staticmethod
+    def is_gh_available():
+        return False
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Patch out app I/O and the agent pty so spawn_agent only drives the UI."""
+    monkeypatch.setattr("lazyagent.app.WorktreeManager", DummyWorktreeManager)
+    monkeypatch.setattr("lazyagent.app.load_config", lambda repo_root: Config())
+    monkeypatch.setattr(WorktreePanel, "_try_start_terminal", lambda self: None)
+    monkeypatch.setattr(LazyAgent, "_refresh_pr_status", lambda self: None)
+
+    def fake_start(self):
+        # Pretend the pty is live without spawning a subprocess. Real queues
+        # so on_resize/on_show (which put set_size messages) don't blow up.
+        import asyncio
+
+        self.emulator = object()
+        self.send_queue = asyncio.Queue()
+        self.recv_queue = asyncio.Queue()
+
+    monkeypatch.setattr(MonitoredTerminal, "start", fake_start)
+    monkeypatch.setattr(MonitoredTerminal, "stop", lambda self: None)
+    monkeypatch.setattr(MonitoredTerminal, "focus", lambda self: self)
+
+
+def _agent_panes(panel: WorktreePanel) -> list[str]:
+    tabs = panel.query_one("#agent-tabs", TabbedContent)
+    return [
+        pane.id
+        for pane in tabs.query(TabPane)
+        if pane.id and pane.id.startswith("agent-tab-")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_spawn_adds_a_tab_per_agent(patched):
+    app = LazyAgent(repo_path="/repo")
+    async with app.run_test() as pilot:
+        center = app.query_one(CenterPanel)
+        panel = await center.switch_to(FEATURE_WORKTREE.path)
+        await pilot.pause()
+
+        a1 = await panel.spawn_agent()
+        a2 = await panel.spawn_agent()
+        await pilot.pause()
+
+        assert [a1, a2] == ["a1", "a2"]
+        assert panel.agent_ids == ["a1", "a2"]
+        assert _agent_panes(panel) == ["agent-tab-a1", "agent-tab-a2"]
+
+        # Newest agent's tab is active, and the placeholder tab is gone.
+        tabs = panel.query_one("#agent-tabs", TabbedContent)
+        assert tabs.active == "agent-tab-a2"
+        with pytest.raises(Exception):
+            panel.query_one(f"#{_PLACEHOLDER_TAB_ID}", TabPane)
+
+        # Diff tab is still present and rightmost.
+        assert panel.query_one(f"#{_DIFF_TAB_ID}", TabPane) is not None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_one_agent_keeps_the_others(patched):
+    app = LazyAgent(repo_path="/repo")
+    async with app.run_test() as pilot:
+        center = app.query_one(CenterPanel)
+        panel = await center.switch_to(FEATURE_WORKTREE.path)
+        await panel.spawn_agent()
+        await panel.spawn_agent()
+        await pilot.pause()
+
+        await panel.cleanup_agent("a1")
+        await pilot.pause()
+
+        assert panel.agent_ids == ["a2"]
+        assert _agent_panes(panel) == ["agent-tab-a2"]
+        # Placeholder not restored while an agent remains.
+        with pytest.raises(Exception):
+            panel.query_one(f"#{_PLACEHOLDER_TAB_ID}", TabPane)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_last_agent_restores_placeholder(patched):
+    app = LazyAgent(repo_path="/repo")
+    async with app.run_test() as pilot:
+        center = app.query_one(CenterPanel)
+        panel = await center.switch_to(FEATURE_WORKTREE.path)
+        await panel.spawn_agent()
+        await pilot.pause()
+
+        await panel.cleanup_agent("a1")
+        await pilot.pause()
+
+        assert panel.agent_ids == []
+        assert _agent_panes(panel) == []
+        # Placeholder tab is back.
+        assert panel.query_one(f"#{_PLACEHOLDER_TAB_ID}", TabPane) is not None
+
+
+@pytest.mark.asyncio
+async def test_active_agent_id_falls_back_to_sole_agent(patched):
+    app = LazyAgent(repo_path="/repo")
+    async with app.run_test() as pilot:
+        center = app.query_one(CenterPanel)
+        panel = await center.switch_to(FEATURE_WORKTREE.path)
+        await panel.spawn_agent()
+        await pilot.pause()
+
+        panel.switch_to_tab(_DIFF_TAB_ID)
+        await pilot.pause()
+        # Even with Diff active, the sole agent is the implicit target.
+        assert panel.active_agent_id == "a1"
+
+
+@pytest.mark.asyncio
+async def test_active_agent_id_none_when_diff_active_and_multiple(patched):
+    app = LazyAgent(repo_path="/repo")
+    async with app.run_test() as pilot:
+        center = app.query_one(CenterPanel)
+        panel = await center.switch_to(FEATURE_WORKTREE.path)
+        await panel.spawn_agent()
+        await panel.spawn_agent()
+        await pilot.pause()
+
+        panel.switch_to_tab(_DIFF_TAB_ID)
+        await pilot.pause()
+        # Ambiguous: Diff active and more than one agent -> no implicit target.
+        assert panel.active_agent_id is None
+
+
+@pytest.mark.asyncio
+async def test_spawn_then_stop_via_app_action(patched):
+    app = LazyAgent(repo_path="/repo")
+    async with app.run_test() as pilot:
+        wt_list = app.query_one(WorktreeList)
+        from lazyagent.widgets.worktree_list import WorktreeListItem
+
+        item = [c for c in wt_list.children if isinstance(c, WorktreeListItem)][1]
+        wt_list.index = 2  # orchestrator(0) + main(1) + feature(2)
+        await app.on_list_view_highlighted(WorktreeList.Highlighted(wt_list, item))
+        await pilot.pause()
+
+        center = app.query_one(CenterPanel)
+        panel = center.get_panel(FEATURE_WORKTREE.path)
+        await panel.spawn_agent()
+        await panel.spawn_agent()
+        await pilot.pause()
+
+        # Two agents tracked? The panel knows; the registry is populated as
+        # status events arrive, so drive a stop of the active (newest) agent.
+        app.notify = lambda *a, **k: None
+        await app.action_stop_agent()
+        await pilot.pause()
+
+        assert panel.agent_ids == ["a1"]
+
+
+# --- Pure roll-up formatting ---
+
+
+def test_rollup_no_agents():
+    assert "---" in format_agents_status({})
+
+
+def test_rollup_single_agent_matches_single_format():
+    states = {"a1": AgentState(status=AgentStatus.RUNNING)}
+    out = format_agents_status(states)
+    assert "running" in out
+    assert "+1" not in out
+
+
+def test_rollup_multiple_shows_dominant_and_overflow():
+    states = {
+        "a1": AgentState(status=AgentStatus.RUNNING),
+        "a2": AgentState(status=AgentStatus.WAITING_FOR_USER),
+    }
+    out = format_agents_status(states)
+    # WAITING_FOR_USER outranks RUNNING in the roll-up.
+    assert "waiting" in out
+    assert "(+1)" in out


### PR DESCRIPTION
## Summary

Adds support for running **multiple coding agents inside a single worktree**, on demand. Previously each worktree had exactly one agent slot (plus the Diff tab). Now:

- Press **`s`** to spawn an *additional* agent in the selected worktree — each gets its own tab to the left of the permanent **Diff** tab.
- Press **`x`** to stop the **active** agent tab (the placeholder is restored when the last agent is stopped).
- The sidebar shows a per-worktree **roll-up** status (e.g. `waiting (+1)`) when more than one agent is running.

Per the agreed design, MCP `spawn_agent` **always creates a new agent** and returns its `agent_id`; it no longer refuses a worktree that already has a running agent.

## Changes by layer

- **Identity** (`models.py`, `messages.py`, `monitored_terminal.py`): `AgentState` gains `agent_id`/`label`; both messages carry `agent_id` (default `""` = legacy/orchestrator); added `rollup_status()` / `dominant_state()`.
- **Panel** (`widgets/center_panel.py`): `WorktreePanel` holds `dict[agent_id → MonitoredTerminal]` with dynamic `TabPane`s (`agent-tab-a1`, …); `spawn_agent()` returns the id; `active_agent_id` falls back to the sole agent.
- **App** (`app.py`): two-level registry `dict[worktree → dict[agent_id → AgentState]]`; status/exit routing, hang-check, spawn/stop/focus, and the remove guard ("any agent running") updated; dropped the single-agent spawn refusal.
- **Sidebar** (`widgets/worktree_list.py`): `format_agents_status()` roll-up; items hold a dict of states.
- **IPC + MCP** (`ipc.py`, `mcp_server.py`): all agent tools take an optional `agent_id` (omit → the one agent; omit with many → `VALIDATION_ERROR` listing the ids). New `list_agents` tool; `list_worktrees` gains an `agents[]` array alongside the back-compat scalar `agent_status`.

The orchestrator stays single-agent via `agent_id=""` (compatible `get_agent`/`agent_ids`/`cleanup_agent(agent_id=None)` interface on `OrchestratorPanel`).

## Tests

- New `tests/test_multi_agent_panel.py` (9 tests): spawn-adds-a-tab, partial/full cleanup, `active_agent_id` fallback/ambiguity, app-action stop, roll-up formatting.
- Updated `test_ipc.py` (resolution + `list_agents` coverage; replaced the obsolete duplicate-spawn rejection), `test_app_integration.py`, `test_monitored_terminal.py` for the new registry/identity shapes.
- **363 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)