### PR TITLE
fix(ipc): submit MCP agent input instead of leaving it in the prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- `send_agent_input` no longer leaves the text sitting unsent in the agent's
+  prompt. The text and the Enter that submits it went out as one PTY write, so
+  the agent CLI read them as a single chunk and — past ~64 characters — parsed
+  the trailing CR as a character inside the message instead of a keypress.
+  Short messages submitted, longer ones didn't, which is why it looked random.
+  The text is now framed as a bracketed paste (when the agent has asked for
+  DECSET 2004) and the submit key is written separately, once the agent has
+  shown it read the text. `LAZYAGENT_SUBMIT_ACK_TIMEOUT` and
+  `LAZYAGENT_SUBMIT_SETTLE_DELAY` tune that handshake
+- Terminal modes (mouse tracking, bracketed paste) are now tracked for hidden
+  terminals too — MCP input usually targets an agent the user isn't looking at
+- Pasting into a terminal pane forwards the text as a real paste, so embedded
+  newlines are content rather than keypresses
+- PTY writes are resumed on a short write instead of silently dropping the tail
+
 ## [0.6.0] - 2026-07-14
 
 ### Added

--- a/src/lazyagent/ipc.py
+++ b/src/lazyagent/ipc.py
@@ -518,14 +518,18 @@ class IpcServer:
 
         agent_id = self._resolve_agent_id(panel.agent_ids, params.get("agent_id"))
         terminal = panel.get_agent(agent_id)
-        if terminal is None or terminal.send_queue is None:
+        if (
+            terminal is None
+            or terminal.emulator is None
+            or terminal.send_queue is None
+        ):
             raise ValueError("Agent terminal is not ready")
 
-        # Append CR (\r) so the agent's TUI treats this as Enter/submit.
-        # Textual delivers Enter as event.character == "\r" in the UI key
-        # handler; LF would be interpreted as Shift+Enter (newline within
-        # the prompt) by Claude Code and most line-editing TUIs.
-        await terminal.send_queue.put(["stdin", text + "\r"])
+        # send_input, not a raw queue put: the text and the Enter that
+        # submits it have to reach the agent CLI as separate reads, or the
+        # CLI parses the trailing CR as a character inside the message and
+        # the prompt just sits there unsent.
+        await terminal.send_input(text, submit=True)
         return _ok(
             request_id,
             {"worktree_path": worktree_path, "agent_id": agent_id, "status": "sent"},

--- a/src/lazyagent/pty_emulator.py
+++ b/src/lazyagent/pty_emulator.py
@@ -96,6 +96,29 @@ class PtyEmulator:
             os.execvpe(argv[0], argv, env)
         return fd
 
+    async def _write_all(self, data: bytes) -> None:
+        """Write every byte of ``data`` to the PTY master.
+
+        ``p_out`` is opened with ``buffering=0``, so ``write`` is a single
+        ``write(2)`` and is allowed to report a short count. Taking that
+        count for granted silently truncates the payload — for stdin that
+        means half an instruction, or a dropped submit key.
+        """
+        view = memoryview(data)
+        while view:
+            try:
+                written = self.p_out.write(view)
+            except BlockingIOError:
+                written = None
+            if written is None:
+                # Would block: yield and retry rather than drop the tail.
+                await asyncio.sleep(0.005)
+                continue
+            if written <= 0:
+                log.warning("PTY write made no progress; %d bytes dropped", len(view))
+                return
+            view = view[written:]
+
     async def _run(self) -> None:
         """Main I/O loop with incremental UTF-8 decoding."""
         decoder = codecs.getincrementaldecoder("utf-8")("replace")
@@ -143,7 +166,7 @@ class PtyEmulator:
             while True:
                 msg = await self.recv_queue.get()
                 if msg[0] == "stdin":
-                    self.p_out.write(msg[1].encode())
+                    await self._write_all(msg[1].encode())
                 elif msg[0] == "set_size":
                     winsize = struct.pack("HH", msg[1], msg[2])
                     fcntl.ioctl(self.fd, termios.TIOCSWINSZ, winsize)
@@ -152,15 +175,15 @@ class PtyEmulator:
                     y = msg[2] + 1
                     button = msg[3]
                     if button == 1:
-                        self.p_out.write(f"\x1b[<0;{x};{y}M".encode())
-                        self.p_out.write(f"\x1b[<0;{x};{y}m".encode())
+                        await self._write_all(f"\x1b[<0;{x};{y}M".encode())
+                        await self._write_all(f"\x1b[<0;{x};{y}m".encode())
                 elif msg[0] == "scroll":
                     x = msg[2] + 1
                     y = msg[3] + 1
                     if msg[1] == "up":
-                        self.p_out.write(f"\x1b[<64;{x};{y}M".encode())
+                        await self._write_all(f"\x1b[<64;{x};{y}M".encode())
                     if msg[1] == "down":
-                        self.p_out.write(f"\x1b[<65;{x};{y}M".encode())
+                        await self._write_all(f"\x1b[<65;{x};{y}M".encode())
         except asyncio.CancelledError:
             pass
         finally:

--- a/src/lazyagent/widgets/scrollable_terminal.py
+++ b/src/lazyagent/widgets/scrollable_terminal.py
@@ -9,6 +9,7 @@ scrollbars) to let users scroll through history.
 from __future__ import annotations
 
 import asyncio
+import os
 import platform
 import re
 import shutil
@@ -43,6 +44,54 @@ _DEFAULT_MAX_SCROLLBACK = 5000
 # observer's lifecycle scan can read a slightly-stale state. Burning CPU on
 # every stdout chunk for off-screen agents was the dominant idle cost.
 _HIDDEN_FEED_INTERVAL = 0.25
+
+# ---------------------------------------------------------------------------
+# Programmatic input framing
+# ---------------------------------------------------------------------------
+#
+# Bracketed paste (DECSET 2004). A real terminal wraps pasted text in these
+# markers so the app can tell "content the user pasted" apart from "keys the
+# user pressed". That distinction is exactly what programmatic input needs:
+# without it, agent CLIs built on Ink (Claude Code, Codex, Gemini) run their
+# stdin chunk through a tokeniser that only splits control characters out as
+# their own key when the whole chunk is short (< 64 chars). A longer chunk
+# ending in CR is absorbed into one text run, so the text lands in the prompt
+# and Enter never fires — the user has to press it by hand. Framing the text
+# as a paste makes the trailing CR a token in its own right no matter how the
+# kernel batches our writes.
+BRACKETED_PASTE_START = "\x1b[200~"
+BRACKETED_PASTE_END = "\x1b[201~"
+
+# Submit key. Enter is CR; LF is Shift+Enter (newline inside the prompt) for
+# Claude Code and most line-editing TUIs.
+SUBMIT_KEY = "\r"
+
+
+def _env_seconds(name: str, default: float) -> float:
+    """Read a non-negative float from the environment, else ``default``."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
+# How long ``send_input`` waits for the child to show any sign of having read
+# what we just wrote before it writes the submit key. Any PTY output is the
+# acknowledgement: it means the child's input loop has run since our write, so
+# the submit key will arrive in a later read() instead of being appended to the
+# same chunk. Bounded, because a busy or silent agent must not stall the submit.
+SUBMIT_ACK_TIMEOUT = _env_seconds("LAZYAGENT_SUBMIT_ACK_TIMEOUT", 2.0)
+
+# Small floor applied after the acknowledgement. The child redraws as soon as
+# it has *parsed* the paste, which can be a beat before its input state has
+# committed; a submit key racing into the same dispatch batch would submit the
+# prompt as it was before the paste. There is no observable signal for that
+# commit, so this one is a delay by necessity — kept tiny and overridable.
+SUBMIT_SETTLE_DELAY = _env_seconds("LAZYAGENT_SUBMIT_SETTLE_DELAY", 0.05)
 
 
 class ScrollbackScreen(pyte.Screen):
@@ -122,6 +171,13 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         self.ncol = 80
         self.nrow = 24
         self.mouse_tracking = False
+        # DECSET 2004 — set once the child asks for bracketed paste. Until
+        # then we must not send paste markers; a child that never requested
+        # them would take the escape sequence for literal input.
+        self.bracketed_paste = False
+        # Set on every PTY stdout chunk; send_input waits on it to know the
+        # child has read what we wrote. See SUBMIT_ACK_TIMEOUT.
+        self._output_event = asyncio.Event()
 
         # PTY emulator (created in start())
         self.emulator: PtyEmulator | None = None
@@ -253,20 +309,17 @@ class ScrollableTerminal(ScrollView, can_focus=True):
                     # promptly even while we're hidden.
                     self._on_stdout(chars)
 
+                    # Terminal modes and the output signal are tracked for
+                    # hidden terminals too: MCP input usually targets an agent
+                    # in a worktree the user isn't looking at, and it needs
+                    # both to frame and submit that input correctly.
+                    self._scan_terminal_modes(chars)
+                    self._output_event.set()
+
                     if self.size.height > 0:
                         # Visible: process immediately so the screen and any
                         # observer scan reflect the latest output.
-                        for sep_match in re.finditer(RE_ANSI_SEQUENCE, chars):
-                            sequence = sep_match.group(0)
-                            if sequence.startswith(DECSET_PREFIX):
-                                parameters = sequence.removeprefix(
-                                    DECSET_PREFIX
-                                ).split(";")
-                                if "1000h" in parameters:
-                                    self.mouse_tracking = True
-                                if "1000l" in parameters:
-                                    self.mouse_tracking = False
-
+                        #
                         # Use the flag instead of is_vertical_scroll_end
                         # which returns unreliable values when the widget is
                         # hidden (e.g. after a ContentSwitcher worktree
@@ -313,6 +366,29 @@ class ScrollableTerminal(ScrollView, can_focus=True):
 
         except asyncio.CancelledError:
             pass
+
+    def _scan_terminal_modes(self, chars: str) -> None:
+        """Track the DECSET private modes we care about in a stdout chunk.
+
+        Mouse tracking (1000) decides whether clicks/scroll go to the child;
+        bracketed paste (2004) decides how ``send_input`` frames text.
+        """
+        for sep_match in re.finditer(RE_ANSI_SEQUENCE, chars):
+            sequence = sep_match.group(0)
+            if not sequence.startswith(DECSET_PREFIX):
+                continue
+            body = sequence.removeprefix(DECSET_PREFIX)
+            action = body[-1:]
+            if action not in ("h", "l"):
+                continue
+            enabled = action == "h"
+            # Only the last parameter carries the final byte: "1000;1006h"
+            # → ["1000", "1006"].
+            modes = body[:-1].split(";")
+            if "1000" in modes:
+                self.mouse_tracking = enabled
+            if "2004" in modes:
+                self.bracketed_paste = enabled
 
     # ------------------------------------------------------------------
     # Hooks for subclasses
@@ -553,6 +629,61 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         return self._detect_color(color)
 
     # ------------------------------------------------------------------
+    # Programmatic input
+    # ------------------------------------------------------------------
+
+    def frame_input(self, text: str) -> str:
+        """Frame ``text`` the way a terminal delivers content, not keystrokes.
+
+        Wrapped in bracketed-paste markers when the child has enabled DECSET
+        2004, which is what stops an embedded control character (in practice
+        the submit CR that follows) from being swallowed into the same text
+        run. Exposed for tests.
+        """
+        # Content newlines are LF. A CR left in the body reads as Enter to any
+        # child that does parse it as a key, which would submit half a message.
+        body = text.replace("\r\n", "\n").replace("\r", "\n")
+        if not self.bracketed_paste:
+            return body
+        # A literal end marker inside the payload would close the paste early
+        # and let the remainder be parsed as keypresses.
+        body = body.replace(BRACKETED_PASTE_END, "")
+        return BRACKETED_PASTE_START + body + BRACKETED_PASTE_END
+
+    async def send_input(self, text: str, *, submit: bool = False) -> None:
+        """Write ``text`` into the child, optionally pressing Enter after it.
+
+        The payload and the submit key are always separate writes, and the
+        submit key is held back until the child has acknowledged the payload
+        (see ``_await_child_ack``). Two writes alone would not be enough — the
+        tty input buffer coalesces back-to-back writes into a single read on
+        the child side.
+        """
+        if self.emulator is None or self.send_queue is None:
+            raise RuntimeError("terminal is not running")
+
+        # Cleared before the write so only output produced *after* it counts
+        # as an acknowledgement.
+        self._output_event.clear()
+        await self.send_queue.put(["stdin", self.frame_input(text)])
+
+        if not submit:
+            return
+
+        await self._await_child_ack()
+        await self.send_queue.put(["stdin", SUBMIT_KEY])
+
+    async def _await_child_ack(self) -> None:
+        """Wait (briefly, and bounded) for the child to react to our write."""
+        try:
+            await asyncio.wait_for(self._output_event.wait(), SUBMIT_ACK_TIMEOUT)
+        except asyncio.TimeoutError:
+            # Silent child — submit anyway rather than drop the instruction.
+            pass
+        if SUBMIT_SETTLE_DELAY > 0:
+            await asyncio.sleep(SUBMIT_SETTLE_DELAY)
+
+    # ------------------------------------------------------------------
     # Input handling
     # ------------------------------------------------------------------
 
@@ -589,7 +720,9 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         if self.emulator is None:
             return
         if event.text:
-            await self.send_queue.put(["stdin", event.text])
+            # Re-frame as a paste for the child; it asked for the markers, and
+            # forwarding raw text lets embedded newlines act as keypresses.
+            await self.send_queue.put(["stdin", self.frame_input(event.text)])
         event.stop()
 
     async def on_click(self, event: events.Click) -> None:

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -395,6 +395,65 @@ class TestReadAgentOutput:
 
         result = await server._dispatch("req-1", "read_agent_output", {"worktree_path": "/tmp/repo"})
         assert "error" in result
+
+
+class TestSendAgentInput:
+    """The handler must go through send_input, which separates the payload
+    from the Enter that submits it — a raw ``text + "\\r"`` write leaves the
+    instruction sitting unsent in the agent's prompt."""
+
+    @staticmethod
+    def _app_with_terminal():
+        app = _make_app(worktrees=[_make_worktree()])
+        terminal = MagicMock()
+        terminal.send_input = AsyncMock()
+        panel = MagicMock()
+        panel.agent_ids = ["a1"]
+        panel.get_agent.return_value = terminal
+        center = MagicMock()
+        center.get_panel.return_value = panel
+        app.query_one.return_value = center
+        return app, terminal
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_send_input_with_submit(self):
+        app, terminal = self._app_with_terminal()
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch(
+            "req-1",
+            "send_agent_input",
+            {"worktree_path": "/tmp/repo", "text": "run the tests"},
+        )
+
+        assert result["result"]["status"] == "sent"
+        terminal.send_input.assert_awaited_once_with("run the tests", submit=True)
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_text(self):
+        app, terminal = self._app_with_terminal()
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch(
+            "req-1", "send_agent_input", {"worktree_path": "/tmp/repo", "text": ""}
+        )
+
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        terminal.send_input.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rejects_a_stopped_terminal(self):
+        """stop() clears the emulator but leaves send_queue pointing at it."""
+        app, terminal = self._app_with_terminal()
+        terminal.emulator = None
+        server = IpcServer(app, "/tmp/test.sock")
+
+        result = await server._dispatch(
+            "req-1", "send_agent_input", {"worktree_path": "/tmp/repo", "text": "hi"}
+        )
+
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        terminal.send_input.assert_not_awaited()
 
 
 class TestDispatch:

--- a/tests/test_pty_emulator.py
+++ b/tests/test_pty_emulator.py
@@ -1,0 +1,63 @@
+"""Tests for PtyEmulator's write path."""
+
+from __future__ import annotations
+
+import pytest
+
+from lazyagent.pty_emulator import PtyEmulator
+
+
+class _ShortWriter:
+    """Stand-in for the unbuffered PTY file object.
+
+    ``buffering=0`` means ``write`` is one ``write(2)`` and may report a short
+    count; ``max_chunk`` reproduces that.
+    """
+
+    def __init__(self, max_chunk: int, block_once: bool = False):
+        self.max_chunk = max_chunk
+        self.written = bytearray()
+        self._block_once = block_once
+
+    def write(self, data) -> int | None:
+        if self._block_once:
+            self._block_once = False
+            return None  # would block
+        chunk = bytes(data[: self.max_chunk])
+        self.written += chunk
+        return len(chunk)
+
+
+def _make_emulator(writer) -> PtyEmulator:
+    emulator = PtyEmulator.__new__(PtyEmulator)
+    emulator.p_out = writer
+    return emulator
+
+
+class TestWriteAll:
+    @pytest.mark.asyncio
+    async def test_short_writes_are_resumed_not_dropped(self):
+        """A truncated payload eats part of the instruction, or the Enter."""
+        writer = _ShortWriter(max_chunk=8)
+        payload = b"a long instruction that will not fit in one write\r"
+
+        await _make_emulator(writer)._write_all(payload)
+
+        assert bytes(writer.written) == payload
+
+    @pytest.mark.asyncio
+    async def test_retries_when_the_write_would_block(self):
+        writer = _ShortWriter(max_chunk=64, block_once=True)
+
+        await _make_emulator(writer)._write_all(b"hello\r")
+
+        assert bytes(writer.written) == b"hello\r"
+
+    @pytest.mark.asyncio
+    async def test_gives_up_when_no_progress_is_possible(self):
+        """Must not spin forever on a writer that accepts nothing."""
+        writer = _ShortWriter(max_chunk=0)
+
+        await _make_emulator(writer)._write_all(b"hello")
+
+        assert bytes(writer.written) == b""

--- a/tests/test_scrollable_terminal.py
+++ b/tests/test_scrollable_terminal.py
@@ -1,6 +1,7 @@
 """Tests for ScrollbackScreen and ScrollableTerminal."""
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pyte
@@ -91,6 +92,8 @@ def _make_scrollable_terminal() -> ScrollableTerminal:
     terminal.ncol = 80
     terminal.nrow = 5
     terminal.mouse_tracking = False
+    terminal.bracketed_paste = False
+    terminal._output_event = asyncio.Event()
     terminal.emulator = None
     terminal.send_queue = None
     terminal.recv_queue = None

--- a/tests/test_terminal_input.py
+++ b/tests/test_terminal_input.py
@@ -1,0 +1,298 @@
+"""Tests for programmatic terminal input (send_agent_input / send_input).
+
+The bug these cover: text sent to an agent CLI landed in its prompt but was
+never submitted, so a human had to press Enter. Agent CLIs built on Ink
+(Claude Code, Codex, Gemini) split a control character out of a stdin chunk
+as its own key event *only while the chunk is short*; past that threshold the
+trailing CR is absorbed into the surrounding text run and inserted as content.
+Framing the payload as a bracketed paste puts the CR outside that run no
+matter how the writes coalesce.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pyte
+import pytest
+
+from lazyagent.widgets.scrollable_terminal import (
+    BRACKETED_PASTE_END,
+    BRACKETED_PASTE_START,
+    ScrollableTerminal,
+    ScrollbackScreen,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal model of the CLI-side tokeniser
+# ---------------------------------------------------------------------------
+
+# Chunk length past which the agent CLI stops treating control characters as
+# their own key and folds them into the surrounding text run.
+_CONTROL_SPLIT_LIMIT = 64
+
+
+def tokenize(chunk: str) -> list[tuple[str, str]]:
+    """Split a stdin chunk the way an Ink-based agent CLI does.
+
+    Reduced to the two rules that matter here: CSI sequences terminate a text
+    run, and a control character only becomes its own token while the whole
+    chunk is under ``_CONTROL_SPLIT_LIMIT``. Returns ``(kind, value)`` pairs
+    with kind in ``{"text", "sequence"}``.
+    """
+    tokens: list[tuple[str, str]] = []
+    run_start = 0
+    i = 0
+
+    def flush(end: int) -> None:
+        nonlocal run_start
+        if end > run_start:
+            tokens.append(("text", chunk[run_start:end]))
+        run_start = end
+
+    while i < len(chunk):
+        ch = chunk[i]
+        if ch == "\x1b" and chunk[i + 1 : i + 2] == "[":
+            flush(i)
+            end = i + 2
+            while end < len(chunk) and not chunk[end].isalpha() and chunk[end] != "~":
+                end += 1
+            end += 1
+            tokens.append(("sequence", chunk[i:end]))
+            i = run_start = end
+            continue
+        if ch < " " and len(chunk) < _CONTROL_SPLIT_LIMIT:
+            flush(i)
+            tokens.append(("text", ch))
+            i = run_start = i + 1
+            continue
+        i += 1
+
+    flush(len(chunk))
+    return tokens
+
+
+def submits(chunk: str) -> bool:
+    """True if the CLI would see a bare Enter outside any pasted content."""
+    in_paste = False
+    for kind, value in tokenize(chunk):
+        if kind == "sequence":
+            if value == BRACKETED_PASTE_START:
+                in_paste = True
+            elif value == BRACKETED_PASTE_END:
+                in_paste = False
+            continue
+        if not in_paste and value == "\r":
+            return True
+    return False
+
+
+LONG = "please review the retry logic in the worker and tell me if it is right"
+SHORT = "yes"
+
+
+class TestTokenizerModel:
+    def test_short_payload_submits_even_unframed(self):
+        """Why the bug looked intermittent: short messages did work."""
+        assert len(SHORT + "\r") < _CONTROL_SPLIT_LIMIT
+        assert submits(SHORT + "\r") is True
+
+    def test_long_payload_does_not_submit_unframed(self):
+        """The old ``text + "\\r"`` payload — CR swallowed into the text run."""
+        assert len(LONG + "\r") >= _CONTROL_SPLIT_LIMIT
+        assert submits(LONG + "\r") is False
+
+    def test_bracketed_paste_submits_even_when_coalesced(self):
+        """The fix holds even if the tty merges both writes into one read."""
+        chunk = BRACKETED_PASTE_START + LONG + BRACKETED_PASTE_END + "\r"
+        assert len(chunk) >= _CONTROL_SPLIT_LIMIT
+        assert submits(chunk) is True
+
+    def test_bracketed_paste_body_is_not_read_as_keys(self):
+        """Newlines inside the payload stay content, they don't submit early."""
+        body = "line one\nline two\nline three"
+        chunk = BRACKETED_PASTE_START + body + BRACKETED_PASTE_END + "\r"
+        pasted = [
+            value
+            for kind, value in tokenize(chunk)
+            if kind == "text" and value != "\r"
+        ]
+        assert "".join(pasted) == body
+        assert submits(chunk) is True
+
+
+# ---------------------------------------------------------------------------
+# ScrollableTerminal framing + submit sequencing
+# ---------------------------------------------------------------------------
+
+
+def _make_terminal(*, bracketed_paste: bool = True) -> ScrollableTerminal:
+    """A ScrollableTerminal with a fake emulator and a real send queue."""
+    t = ScrollableTerminal.__new__(ScrollableTerminal)
+    t.ncol = 80
+    t.nrow = 5
+    t.mouse_tracking = False
+    t.bracketed_paste = bracketed_paste
+    t._output_event = asyncio.Event()
+    t.emulator = object()
+    t.send_queue = asyncio.Queue()
+    t._screen = ScrollbackScreen(80, 5)
+    t.stream = pyte.Stream(t._screen)
+    return t
+
+
+def _drain(queue: asyncio.Queue) -> list[list]:
+    items = []
+    while not queue.empty():
+        items.append(queue.get_nowait())
+    return items
+
+
+class TestFrameInput:
+    def test_wraps_in_paste_markers_when_child_asked_for_them(self):
+        t = _make_terminal(bracketed_paste=True)
+        assert t.frame_input("hello") == (
+            BRACKETED_PASTE_START + "hello" + BRACKETED_PASTE_END
+        )
+
+    def test_no_markers_when_child_did_not_enable_them(self):
+        """Unrequested markers would be inserted as literal junk."""
+        t = _make_terminal(bracketed_paste=False)
+        assert t.frame_input("hello") == "hello"
+
+    def test_carriage_returns_in_body_become_newlines(self):
+        t = _make_terminal(bracketed_paste=False)
+        assert t.frame_input("a\r\nb\rc") == "a\nb\nc"
+
+    def test_embedded_end_marker_is_stripped(self):
+        """Otherwise the payload could close its own paste and inject keys."""
+        t = _make_terminal(bracketed_paste=True)
+        framed = t.frame_input(f"safe{BRACKETED_PASTE_END}\rrm -rf /")
+        assert framed.count(BRACKETED_PASTE_END) == 1
+        assert framed.endswith(BRACKETED_PASTE_END)
+
+
+class TestSendInput:
+    @pytest.mark.asyncio
+    async def test_submit_key_is_a_separate_write(self):
+        t = _make_terminal()
+        t._output_event.set()  # child already acknowledged
+
+        await t.send_input(LONG, submit=True)
+
+        writes = _drain(t.send_queue)
+        assert writes == [
+            ["stdin", BRACKETED_PASTE_START + LONG + BRACKETED_PASTE_END],
+            ["stdin", "\r"],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_no_submit_key_when_not_submitting(self):
+        t = _make_terminal()
+        await t.send_input("hello", submit=False)
+        assert len(_drain(t.send_queue)) == 1
+
+    @pytest.mark.asyncio
+    async def test_submit_waits_for_the_child_to_acknowledge(self):
+        """The CR is held until the child produces output after our write."""
+        t = _make_terminal()
+
+        task = asyncio.create_task(t.send_input(LONG, submit=True))
+        await asyncio.sleep(0.05)
+
+        assert [w[1] for w in _drain(t.send_queue)] == [
+            BRACKETED_PASTE_START + LONG + BRACKETED_PASTE_END
+        ]
+
+        t._output_event.set()  # child redrew — it has read the paste
+        await task
+        assert [w[1] for w in _drain(t.send_queue)] == ["\r"]
+
+    @pytest.mark.asyncio
+    async def test_submits_anyway_when_the_child_stays_silent(self, monkeypatch):
+        """A quiet agent must not swallow the instruction entirely."""
+        monkeypatch.setattr(
+            "lazyagent.widgets.scrollable_terminal.SUBMIT_ACK_TIMEOUT", 0.05
+        )
+        t = _make_terminal()
+
+        await t.send_input(LONG, submit=True)
+
+        assert [w[1] for w in _drain(t.send_queue)][-1] == "\r"
+
+    @pytest.mark.asyncio
+    async def test_stale_output_does_not_count_as_acknowledgement(self):
+        """Output from before our write must not release the submit key."""
+        t = _make_terminal()
+        t._output_event.set()  # output from before we wrote anything
+
+        task = asyncio.create_task(t.send_input(LONG, submit=True))
+        await asyncio.sleep(0)
+        # send_input clears the flag before writing, so this is a fresh wait.
+        assert t._output_event.is_set() is False
+        t._output_event.set()
+        await task
+
+    @pytest.mark.asyncio
+    async def test_raises_when_the_terminal_is_not_running(self):
+        t = _make_terminal()
+        t.emulator = None
+        with pytest.raises(RuntimeError):
+            await t.send_input("hello", submit=True)
+
+
+class TestModeTracking:
+    def test_bracketed_paste_enable_and_disable(self):
+        t = _make_terminal(bracketed_paste=False)
+        t._scan_terminal_modes("\x1b[?2004h")
+        assert t.bracketed_paste is True
+        t._scan_terminal_modes("\x1b[?2004l")
+        assert t.bracketed_paste is False
+
+    def test_mode_in_a_multi_parameter_decset(self):
+        t = _make_terminal(bracketed_paste=False)
+        t._scan_terminal_modes("\x1b[?1000;1006;2004h")
+        assert t.bracketed_paste is True
+        assert t.mouse_tracking is True
+
+    def test_mouse_tracking_still_tracked(self):
+        t = _make_terminal()
+        t._scan_terminal_modes("\x1b[?1000h")
+        assert t.mouse_tracking is True
+        t._scan_terminal_modes("\x1b[?1000l")
+        assert t.mouse_tracking is False
+
+    def test_unrelated_sequences_are_ignored(self):
+        t = _make_terminal(bracketed_paste=False)
+        t._scan_terminal_modes("\x1b[2J\x1b[?25l\x1b[1;5H")
+        assert t.bracketed_paste is False
+        assert t.mouse_tracking is False
+
+
+class TestModeTrackingWhileHidden:
+    """A hidden agent is the normal MCP target; its modes must stay current."""
+
+    @pytest.mark.asyncio
+    async def test_recv_tracks_modes_for_a_zero_height_widget(self):
+        from unittest.mock import PropertyMock, patch
+
+        from textual.geometry import Size
+
+        t = _make_terminal(bracketed_paste=False)
+        t._stopped = False
+        t._hidden_feed_buffer = []
+        t._hidden_feed_handle = None
+        t.recv_queue = asyncio.Queue()
+        t.recv_queue.put_nowait(["stdout", "\x1b[?2004h"])
+
+        with patch.object(
+            type(t), "size", new_callable=PropertyMock, return_value=Size(0, 0)
+        ):
+            task = asyncio.create_task(t.recv())
+            await asyncio.sleep(0.01)
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        assert t.bracketed_paste is True
+        assert t._output_event.is_set() is True


### PR DESCRIPTION
## Problem

Text sent with `send_agent_input` landed in the target agent's prompt but was never submitted — you had to press Enter in the TUI yourself. It looked intermittent.

**It wasn't random: it was length-dependent.** Short instructions submitted, longer ones didn't.

## Root cause

The text and the CR that submits it went out as a **single PTY write** (`ipc.py:528` → `pty_emulator.py:146`), so the agent CLI read them as one stdin chunk. Ink-based agent CLIs (Claude Code, Codex, Gemini) tokenise a chunk with this rule:

```js
else if (!forOutput && charCode < 32 && chunk.length < 64) { /* control char becomes its own key */ }
else c++;   // otherwise: absorbed into the surrounding text run
```

Past ~64 characters the trailing CR is folded into the text run and inserted as **content**. Hence: prompt filled, Enter never fires.

Verified against the tokeniser in the Claude Code binary (`~/.local/share/claude/versions/2.1.220`, fn `fFu`; dispatcher `Dcy`; `BRACKETED_PASTE:2004`).

`spawn_agent`'s `instruction` is **not** affected — it goes via argv (`agent_providers.py:93-97`), never through the PTY.

## Why two writes aren't enough

Splitting into two `write()` calls does not fix it — the tty input buffer **coalesces back-to-back writes into a single `read()`** on the child side. Reproduced against a live PTY:

```
b'please review the diff and tell me if the retry logic is correct, thanks\r'   # one write
b'please review the diff and tell me if the retry logic is correct, thanks\r'   # two writes, no wait
b'please review the diff and tell me if the retry logic is correct, thanks'     # two writes, child read in between
b'\r'
```

## Fix

Frame the payload as a **bracketed paste** (`\e[200~`…`\e[201~`) when the child has enabled DECSET 2004. Even in a fully coalesced chunk the paste-end sequence resets the tokeniser's run pointer, so the trailing CR emerges as its own token → a real `return` key. **Timing-independent.**

The submit key is still a separate write, held until the child emits output (evidence its input loop has run since ours), bounded by `LAZYAGENT_SUBMIT_ACK_TIMEOUT` (2.0s). A small `LAZYAGENT_SUBMIT_SETTLE_DELAY` (0.05s) floor guards a separate, speculative risk — the submit landing in the same dispatch batch as the paste — for which no observable signal exists. It is not load-bearing for the root cause.

Also in here:

- **DECSET modes are now tracked for hidden terminals.** The scan sat inside `if self.size.height > 0`, so an off-screen agent never learned its own mode state — and MCP input normally targets a worktree you aren't looking at. Also fixes stale mouse-tracking state, and handles `\e[?1000;1006;2004h` (the old check only matched when the mode was the *last* parameter).
- User pastes into a terminal pane forward as real pastes, so embedded newlines stay content.
- `PtyEmulator` resumes short writes instead of silently dropping the tail (`buffering=0` means `write` is one `write(2)` and may report a short count).

## Testing

390 tests pass.

- `tests/test_terminal_input.py` — ports the CLI-side tokeniser rule and asserts the old payload fails to submit while the framed one succeeds *even when coalesced*; framing, end-marker stripping, submit sequencing, ack timeout, hidden-terminal mode tracking.
- `tests/test_pty_emulator.py` — short writes, would-block retry, no-progress bail-out.
- `tests/test_ipc.py` — handler delegates to `send_input(..., submit=True)`.

**End-to-end against a live PTY** driving the real `PtyEmulator` + `send_input`: child announced `\e[?2004h`, payload arrived framed, CR arrived as its own read chunk.

⚠️ **Not verified against the real CLI.** The e2e used a stub child, and the "would submit" verdict comes from a model of the tokeniser ported from the disassembled binary — not from Claude Code actually submitting. The bytes on the wire are confirmed correct; the CLI's reaction to them is inferred. Worth a manual smoke test before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)