### PR TITLE
perf: 7.5x cheaper terminal frames, 33x smaller scrollback, and no more git-status UI freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   re-listing worktrees the way `r` does
 
 ### Performance
+- A pane now repaints only the rows that changed instead of all of them. An
+  agent's output arrives in small pieces — a spinner tick, a few streamed
+  tokens — and each one used to repaint every visible row: a traced session
+  spent 43 seconds rendering against 1.2 seconds parsing, with 95% of those
+  repaints caused by chunks under 100 characters. Measured at 9.25 ms to
+  1.76 ms per chunk, and 42 rendered rows down to 1.7
 - Terminal panes render roughly 7x cheaper per frame: rows are run-length
   encoded into styled segments instead of being built a character at a time,
   and resolved styles are cached per pane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `Alt+G` refreshes the git status of the selected worktree on demand, without
+  re-listing worktrees the way `r` does
+
+### Fixed
+- The periodic git-status refresh no longer freezes the UI. It ran `git status`
+  for *every* worktree, serially, on the message pump — about three seconds of
+  a completely unresponsive app twice a minute on a repo with 22 worktrees. It
+  now runs in a worker thread, polls only the selected worktree, and does so
+  once a minute instead of twice. Every worktree still refreshes on `r`, on
+  create/remove, and on MCP worktree changes
+
 ## [0.6.0] - 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   now runs in a worker thread, polls only the selected worktree, and does so
   once a minute instead of twice. Every worktree still refreshes on `r`, on
   create/remove, and on MCP worktree changes
+- Scrolling the sidebar no longer fires a `git status` for every worktree
+  passed through — the selection-triggered refresh waits for the selection to
+  settle first
 
 ## [0.6.0] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Performance
+- Terminal panes render roughly 7x cheaper per frame: rows are run-length
+  encoded into styled segments instead of being built a character at a time,
+  and resolved styles are cached per pane
+- Scrollback now costs ~2.8 MB per terminal instead of ~91 MB at the 5000-line
+  default, and no longer holds GC-tracked objects. Full garbage collections
+  with six worktrees' worth of history drop from ~800 ms — a visible freeze of
+  the whole UI — to under 20 ms, and no longer grow with the number of
+  worktrees that have scrollback, idle or not
+- Terminal output parsing is ~3x faster for plain ASCII, which is most of it.
+  Each additional streaming agent now costs about a fifth of what it did, so
+  several busy worktrees no longer saturate a core
+
+### Fixed
+- A styled cell in the rightmost column of a terminal is no longer painted with
+  its left neighbour's style (visible as a box border or right-aligned badge
+  losing its colour)
+
 ## [0.6.0] - 2026-07-14
 
 ### Added

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -7,6 +7,7 @@ import sys
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
+from textual.timer import Timer
 from textual.widgets import Footer, Header
 from textual import work
 
@@ -24,6 +25,12 @@ from lazyagent.widgets.prompt_modal import SpawnModal, SpawnResult
 from lazyagent.widgets.orchestrator_panel import ORCHESTRATOR_KEY
 from lazyagent.widgets.worktree_list import OrchestratorListItem, WorktreeList, WorktreeListItem
 from lazyagent.worktree_manager import WorktreeManager, WorktreeManagerError, find_repo_root
+
+
+# How long the selection has to settle before we fetch its git status.
+# Scrolling the sidebar with j/k should not spawn a `git status` per worktree
+# passed through — only the one actually landed on.
+_GIT_STATUS_DEBOUNCE = 0.4
 
 
 class LazyAgent(App):
@@ -93,6 +100,7 @@ class LazyAgent(App):
         self._gh_available: bool | None = None
         self._ipc_server: IpcServer | None = None
         self._ipc_socket_path: str | None = None
+        self._git_status_debounce: Timer | None = None
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -219,6 +227,26 @@ class LazyAgent(App):
             return
         self.call_from_thread(self._apply_git_statuses, statuses)
 
+    def _cancel_git_status_debounce(self) -> None:
+        """Drop a pending selection-triggered git status fetch."""
+        if self._git_status_debounce is not None:
+            self._git_status_debounce.stop()
+            self._git_status_debounce = None
+
+    def _schedule_selected_git_status(self) -> None:
+        """Fetch the selected worktree's git status once the selection settles.
+
+        Debounced rather than immediate: scrolling the sidebar with j/k would
+        otherwise spawn a ``git status`` for every worktree passed through, and
+        those subprocesses are the expensive part. ``exclusive=True`` on the
+        worker cancels *waiting* on a superseded fetch but cannot stop a
+        subprocess already running, so the throttle has to happen here.
+        """
+        self._cancel_git_status_debounce()
+        self._git_status_debounce = self.set_timer(
+            _GIT_STATUS_DEBOUNCE, self._refresh_selected_git_status
+        )
+
     @work(thread=True, exclusive=True, group="git_status_selected")
     def _refresh_selected_git_status(self) -> None:
         """Fetch git status for the selected worktree only (runs in a thread).
@@ -314,6 +342,8 @@ class LazyAgent(App):
 
     async def on_list_view_highlighted(self, event: WorktreeList.Highlighted) -> None:
         center = self.query_one(CenterPanel)
+        # Any move invalidates a fetch queued for the worktree we just left.
+        self._cancel_git_status_debounce()
         if event.item is not None and isinstance(event.item, OrchestratorListItem):
             self._orchestrator_selected = True
             self._selected_worktree = None
@@ -323,10 +353,11 @@ class LazyAgent(App):
             self._selected_worktree = event.item.worktree
             await center.switch_to(event.item.worktree.path)
             self._push_git_status_to_selected_panel()
-            # Show the cached badge immediately, then refresh it: the periodic
-            # poll only covers whichever worktree was selected at the time, so
-            # the one we just moved to may be holding a stale status.
-            self._refresh_selected_git_status()
+            # Show the cached badge immediately, then refresh it once the
+            # selection settles: the periodic poll only covers whichever
+            # worktree was selected at the time, so the one we just moved to
+            # may be holding a stale status.
+            self._schedule_selected_git_status()
             self._refresh_selected_diff()
             self._refresh_pr_status()
         else:
@@ -562,6 +593,8 @@ class LazyAgent(App):
         """Refresh git status for the selected worktree, nothing else."""
         if self._selected_worktree is None:
             return
+        # Explicit request — fire now, and drop any debounced fetch it obsoletes.
+        self._cancel_git_status_debounce()
         self._refresh_selected_git_status()
         self.notify("Refreshing git status…", timeout=2)
 

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -70,6 +70,10 @@ class LazyAgent(App):
         # bound as universal fallbacks that keep the modifier everywhere.
         Binding("alt+right_square_bracket,alt+n", "next_agent", "Next agent", priority=True),
         Binding("alt+left_square_bracket,alt+p", "prev_agent", "Prev agent", priority=True),
+        # Git status only — no worktree re-list. priority=True so it works
+        # while a terminal pane has focus, which is exactly when you want it
+        # (you just committed and want the badge to catch up).
+        Binding("alt+g", "refresh_git_status", "Git status", priority=True),
         Binding("question_mark", "help", "Help"),
     ]
 
@@ -103,7 +107,12 @@ class LazyAgent(App):
         self._load_config()
         await self._start_ipc_server()
         self.set_interval(60, self._check_hangs)
-        self.set_interval(30, self._refresh_git_statuses)
+        # Only the selected worktree is polled, and only once a minute:
+        # `git status` walks the whole working tree, so sweeping every
+        # worktree on a timer costs seconds on a repo with many of them.
+        # The other worktrees refresh on the full rescan (`r`, create,
+        # remove, MCP), and Alt+G refreshes the selected one on demand.
+        self.set_interval(60, self._refresh_selected_git_status)
         self.set_interval(30, self._refresh_selected_diff)
         self.set_interval(60, self._refresh_pr_status)
 
@@ -190,17 +199,53 @@ class LazyAgent(App):
             return center.get_orchestrator_panel()
         return center.get_panel(key)
 
+    @work(thread=True, exclusive=True, group="git_status_all")
     def _refresh_git_statuses(self) -> None:
-        """Fetch git statuses for all worktrees and push to UI."""
-        if not self._repo_root or not self.worktrees:
+        """Fetch git status for every worktree (runs in a thread).
+
+        ``git status`` walks the whole working tree — on a repo with a couple
+        of dozen worktrees this sweep takes seconds, so it must never run on
+        the message pump. Only the full-rescan paths need it; the periodic
+        poll refreshes just the selected worktree.
+        """
+        repo_root = self._repo_root
+        worktrees = list(self.worktrees)
+        if not repo_root or not worktrees:
             return
         try:
-            manager = WorktreeManager(self._repo_root)
-            self._git_statuses = manager.get_all_git_statuses(self.worktrees)
+            manager = WorktreeManager(repo_root)
+            statuses = manager.get_all_git_statuses(worktrees)
         except WorktreeManagerError:
             return
+        self.call_from_thread(self._apply_git_statuses, statuses)
 
-        self.query_one(WorktreeList).update_all_git_statuses(self._git_statuses)
+    @work(thread=True, exclusive=True, group="git_status_selected")
+    def _refresh_selected_git_status(self) -> None:
+        """Fetch git status for the selected worktree only (runs in a thread).
+
+        ``exclusive=True`` drops an in-flight fetch when the selection moves
+        or the user asks again — only the current worktree's answer matters.
+        """
+        repo_root = self._repo_root
+        wt = self._selected_worktree
+        if not repo_root or wt is None or wt.is_bare:
+            return
+        try:
+            manager = WorktreeManager(repo_root)
+            status = manager.get_git_status(wt.path)
+            status.last_commit_subject = manager.get_last_commit_subject(wt.path)
+        except WorktreeManagerError:
+            return
+        self.call_from_thread(self._apply_git_statuses, {wt.path: status})
+
+    def _apply_git_statuses(self, statuses: dict[str, GitStatus]) -> None:
+        """Merge fetched statuses into the cache and UI — runs on the main thread.
+
+        Merges rather than replaces: a selected-worktree refresh must not drop
+        the statuses the last full sweep collected for the others.
+        """
+        self._git_statuses.update(statuses)
+        self.query_one(WorktreeList).update_all_git_statuses(statuses)
         self._push_git_status_to_selected_panel()
 
     def _push_git_status_to_selected_panel(self) -> None:
@@ -278,6 +323,10 @@ class LazyAgent(App):
             self._selected_worktree = event.item.worktree
             await center.switch_to(event.item.worktree.path)
             self._push_git_status_to_selected_panel()
+            # Show the cached badge immediately, then refresh it: the periodic
+            # poll only covers whichever worktree was selected at the time, so
+            # the one we just moved to may be holding a stale status.
+            self._refresh_selected_git_status()
             self._refresh_selected_diff()
             self._refresh_pr_status()
         else:
@@ -508,6 +557,13 @@ class LazyAgent(App):
     def action_refresh(self) -> None:
         self._load_worktrees()
         self.notify("Refreshed worktrees")
+
+    def action_refresh_git_status(self) -> None:
+        """Refresh git status for the selected worktree, nothing else."""
+        if self._selected_worktree is None:
+            return
+        self._refresh_selected_git_status()
+        self.notify("Refreshing git status…", timeout=2)
 
     def action_create_worktree(self) -> None:
         def on_modal_dismiss(result: CreateWorktreeResult | None) -> None:

--- a/src/lazyagent/ipc.py
+++ b/src/lazyagent/ipc.py
@@ -462,12 +462,6 @@ class IpcServer:
         screen = terminal._screen
         total_lines = len(screen.scrollback) + screen.lines
 
-        def _row_text(row_data: dict) -> str:
-            return "".join(
-                row_data.get(x, screen.default_char).data
-                for x in range(screen.columns)
-            ).rstrip()
-
         # Collect only the last num_lines by iterating from the end:
         # first the live screen buffer (bottom), then scrollback (top).
         collected: list[str] = []
@@ -477,15 +471,15 @@ class IpcServer:
         for row in range(screen.lines - 1, -1, -1):
             if remaining <= 0:
                 break
-            collected.append(_row_text(screen.buffer[row]))
+            collected.append(screen.screen_text(row))
             remaining -= 1
 
         # Scrollback lines (bottom-up)
         if remaining > 0:
-            for row_data in reversed(screen.scrollback):
+            for index in range(len(screen.scrollback) - 1, -1, -1):
                 if remaining <= 0:
                     break
-                collected.append(_row_text(row_data))
+                collected.append(screen.scrollback_text(index))
                 remaining -= 1
 
         collected.reverse()

--- a/src/lazyagent/pyte_patch.py
+++ b/src/lazyagent/pyte_patch.py
@@ -13,7 +13,11 @@ Import this module before any pyte usage. It:
 3. Overrides ``pyte.Screen.select_graphic_rendition`` so that SGR 22 resets
    **both** bold and dim (per ANSI spec, SGR 22 = "normal intensity").
 
-4. Wraps ``pyte.streams.Stream.feed`` with a state-machine pre-filter that:
+4. Adds a fast path to ``pyte.Screen.draw`` for plain ASCII runs that fit on
+   the current line — the overwhelmingly common case, and the single most
+   expensive thing lazyagent does with a streaming agent.
+
+5. Wraps ``pyte.streams.Stream.feed`` with a state-machine pre-filter that:
    - Drops DCS sequences (``\\eP...\\e\\``). Claude Code v2.1.x uses these for
      tmux passthrough of OSC 9 notifications; without filtering, the literal
      content (``tmux;]9;Claude is waiting for your input``) leaks into the
@@ -29,7 +33,9 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
+import pyte.charsets
 import pyte.graphics
+import pyte.modes
 import pyte.screens
 import pyte.streams
 
@@ -81,7 +87,72 @@ def _patched_sgr(self: pyte.screens.Screen, *attrs: int) -> None:
 pyte.screens.Screen.select_graphic_rendition = _patched_sgr
 
 # ---------------------------------------------------------------------------
-# 4. Stream-level pre-filter for DCS and CSI sub-parameters
+# 4. Fast path for Screen.draw
+# ---------------------------------------------------------------------------
+
+_orig_draw = pyte.screens.Screen.draw
+
+
+def _patched_draw(self: pyte.screens.Screen, data: str) -> None:
+    """Draw a run of plain ASCII that fits on the current line.
+
+    pyte's ``draw`` is the single hottest thing in lazyagent under a
+    streaming agent: for every character it calls ``wcwidth``, tests two
+    modes, re-reads ``self.cursor``/``self.buffer``, and builds the cell with
+    ``Char._replace`` — a NamedTuple ``_replace`` is roughly ten times the
+    cost of the tuple construction it wraps.
+
+    Everything the general path exists for is excluded up front and delegated
+    to the original:
+
+    * a run that would reach the right margin (wrapping, DECAWM, the
+      pending-wrap state where ``cursor.x == columns``),
+    * insert mode (IRM), where drawing shifts existing cells right,
+    * an active charset other than Latin-1 — ``\\e(0`` remaps ASCII to VT100
+      box drawing, so the translate pass is *not* optional,
+    * anything that is not printable ASCII: wide characters need a stub
+      cell, combining characters merge into the previous cell, and
+      unprintables stop the loop.
+
+    Printable ASCII is exactly the set of characters that are unconditionally
+    one cell wide, so the fast path needs no ``wcwidth`` call at all.
+    """
+    cursor = self.cursor
+    x = cursor.x
+    if (
+        x + len(data) > self.columns
+        or pyte.modes.IRM in self.mode
+        or (self.g1_charset if self.charset else self.g0_charset)
+        is not pyte.charsets.LAT1_MAP
+        or not data.isascii()
+        or not data.isprintable()
+    ):
+        _orig_draw(self, data)
+        return
+
+    line = self.buffer[cursor.y]
+    attrs = cursor.attrs
+    # attrs cannot change inside one draw() call, so every cell differs only
+    # in `data`. Build each distinct character once and share the Char — it
+    # is immutable, and sharing cuts allocation in the live buffer too.
+    tail = attrs[1:]
+    make = attrs._make
+    cache: dict[str, Char] = {}
+    for char in data:
+        cell = cache.get(char)
+        if cell is None:
+            cell = cache[char] = make((char,) + tail)
+        line[x] = cell
+        x += 1
+
+    cursor.x = x
+    self.dirty.add(cursor.y)
+
+
+pyte.screens.Screen.draw = _patched_draw
+
+# ---------------------------------------------------------------------------
+# 5. Stream-level pre-filter for DCS and CSI sub-parameters
 # ---------------------------------------------------------------------------
 
 

--- a/src/lazyagent/widgets/help_modal.py
+++ b/src/lazyagent/widgets/help_modal.py
@@ -25,7 +25,8 @@ _HELP_TEXT = """\
 [bold cyan]Worktrees[/bold cyan]
   [bold]c[/bold]               Create new worktree
   [bold]d[/bold]               Remove selected worktree
-  [bold]r[/bold]               Refresh worktree list
+  [bold]r[/bold]               Refresh worktree list (and every git status)
+  [bold]Alt+G[/bold]           Refresh git status of the selected worktree
 
 [bold cyan]Terminal scrollback[/bold cyan]
   [bold]PageUp / PageDown[/bold]  Scroll terminal history

--- a/src/lazyagent/widgets/scrollable_terminal.py
+++ b/src/lazyagent/widgets/scrollable_terminal.py
@@ -19,9 +19,9 @@ import pyte
 from pyte.screens import Char, Margins
 
 from rich.color import ColorParseError
+from rich.control import strip_control_codes
 from rich.segment import Segment
 from rich.style import Style
-from rich.text import Text
 
 from textual import events, log
 from textual.geometry import Offset, Size
@@ -43,6 +43,30 @@ _DEFAULT_MAX_SCROLLBACK = 5000
 # observer's lifecycle scan can read a slightly-stale state. Burning CPU on
 # every stdout chunk for off-screen agents was the dominant idle cost.
 _HIDDEN_FEED_INTERVAL = 0.25
+
+# Upper bound on the per-widget style cache. A real screen has a few dozen
+# distinct styles, but a truecolor-heavy app (image renderer, gradient) can
+# generate one per cell — cap the cache so it cannot grow without bound.
+_MAX_STYLE_CACHE = 4096
+
+
+def _style_key(char: Char) -> tuple:
+    """Return every field of a pyte ``Char`` except ``data`` as a plain tuple.
+
+    Used both as the key of the rendered-``Style`` cache and as the style
+    element of the compact scrollback rows.
+
+    Slicing a ``Char`` is deliberate on two counts. It is a single C-level
+    operation instead of eight attribute loads, which matters because this
+    runs once per cell per repaint. And slicing a tuple subclass yields an
+    *exact* ``tuple``, which is what lets the GC untrack it (see
+    :class:`ScrollbackScreen`) — do not "clean this up" into a NamedTuple.
+
+    The first eight fields are the ones the renderer honours;
+    :meth:`ScrollableTerminal._cached_style` ignores any extra (today just
+    ``dim``, which pyte_patch tracks but the renderer has never applied).
+    """
+    return char[1:]
 
 
 class ScrollbackScreen(pyte.Screen):
@@ -148,6 +172,9 @@ class ScrollableTerminal(ScrollView, can_focus=True):
 
         # Cached resolved default colors (invalidated on theme change)
         self._cached_default_colors: tuple[str, str] | None = None
+
+        # style key (see _style_key) → rich.Style, invalidated on theme change
+        self._style_cache: dict[tuple, Style] = {}
 
         # Key translation table (same as textual-terminal)
         self.ctrl_keys = {
@@ -414,30 +441,97 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         virtual_y: int = -1,
     ) -> Strip:
         """Convert a pyte row (dict of column→Char) to a textual Strip."""
-        text = Text()
         ncols = max(width, self._screen.columns)
-        style_change_pos: int = 0
+        text, runs = self._encode_row(row, ncols)
+
+        cursor_x = -1
+        cursor_style: Style | None = None
+        if show_cursor and 0 <= self._screen.cursor.x < ncols:
+            cursor_x = self._screen.cursor.x
+            cursor_style = self._cursor_style(
+                row.get(cursor_x, self._screen.default_char)
+            )
+
+        return self._runs_to_strip(
+            text,
+            runs,
+            ncols,
+            cursor_x=cursor_x,
+            cursor_style=cursor_style,
+            virtual_y=virtual_y,
+        )
+
+    def _encode_row(
+        self, row: dict[int, Char], ncols: int
+    ) -> tuple[str, list[tuple[int, int, tuple]]]:
+        """Run-length encode a live pyte row into ``(text, runs)``.
+
+        ``runs`` is a list of ``(start, end, style_key)`` with offsets into
+        ``text``. One pass, one tuple per cell, and no ``rich`` objects — the
+        old per-cell ``Text.append`` + ``stylize`` version was 53% of the
+        widget's CPU under a streaming agent.
+        """
+        default_char = self._screen.default_char
+        get = row.get
+        parts: list[str] = []
+        runs: list[tuple[int, int, tuple]] = []
+        buf: list[str] = []
+        cur_key: tuple | None = None
+        start = 0
 
         for x in range(ncols):
-            char: Char = row.get(x, self._screen.default_char)
-            text.append(char.data)
+            char = get(x, default_char)
+            # Index instead of attribute access, and _style_key inlined: this
+            # runs once per cell per repaint, so descriptor lookups show up.
+            key = char[1:]
+            if key != cur_key:
+                if buf:
+                    run = "".join(buf)
+                    parts.append(run)
+                    end = start + len(run)
+                    runs.append((start, end, cur_key))
+                    start = end
+                    buf.clear()
+                cur_key = key
+            buf.append(char[0])
 
-            if x > 0:
-                last_char: Char = row.get(x - 1, self._screen.default_char)
-                if (
-                    not self._char_style_cmp(char, last_char)
-                    or x == ncols - 1
-                ):
-                    last_style = self._char_rich_style(last_char)
-                    text.stylize(last_style, style_change_pos, x + 1)
-                    style_change_pos = x
+        if buf:
+            run = "".join(buf)
+            parts.append(run)
+            runs.append((start, start + len(run), cur_key))
 
-        # Apply cursor style AFTER all character styles so it is never
-        # overwritten by a later stylize() call that covers the same range.
-        if show_cursor and 0 <= self._screen.cursor.x < ncols:
-            cx = self._screen.cursor.x
-            cursor_char: Char = row.get(cx, self._screen.default_char)
-            text.stylize(self._cursor_style(cursor_char), cx, cx + 1)
+        return "".join(parts), runs
+
+    def _runs_to_strip(
+        self,
+        text: str,
+        runs: list[tuple[int, int, tuple]] | tuple[tuple[int, int, tuple], ...],
+        ncols: int,
+        *,
+        cursor_x: int = -1,
+        cursor_style: Style | None = None,
+        virtual_y: int = -1,
+    ) -> Strip:
+        """Build a Strip from run-length encoded style runs.
+
+        Shared by the live-screen and scrollback paths. ``text`` may be
+        shorter than ``ncols`` (scrollback rows drop trailing blanks); the
+        remainder is padded with default-styled spaces, which is what the
+        live path produces for unwritten cells.
+        """
+        pad = ncols - len(text)
+        if pad > 0:
+            runs = [*runs, (len(text), ncols, _style_key(self._screen.default_char))]
+            text = text + " " * pad
+
+        # Overlays are applied in insertion order, mirroring the order the
+        # old implementation called Text.stylize() in: character styles
+        # first, then the cursor, then the selection. Later overlays win on
+        # the attributes they set, so the cursor's fg/bg swap is never
+        # overwritten by a character style.
+        overlays: list[tuple[int, int, Style]] = []
+        if cursor_style is not None:
+            overlays.append((cursor_x, cursor_x + 1, cursor_style))
 
         selection = self._cached_selection
         if selection is not None and virtual_y >= 0:
@@ -450,9 +544,36 @@ class ScrollableTerminal(ScrollView, can_focus=True):
                     self._cached_selection_style = (
                         self.screen.get_component_rich_style("screen--selection")
                     )
-                text.stylize(self._cached_selection_style, start, end)
+                overlays.append((start, end, self._cached_selection_style))
 
-        segments = list(text.render(self.app.console))
+        cached_style = self._cached_style
+        if not overlays:
+            return Strip(
+                [
+                    Segment(strip_control_codes(text[start:end]), cached_style(key))
+                    for start, end, key in runs
+                ]
+            )
+
+        segments: list[Segment] = []
+        for start, end, key in runs:
+            base = cached_style(key)
+            cuts = {start, end}
+            for over_start, over_end, _ in overlays:
+                if start < over_start < end:
+                    cuts.add(over_start)
+                if start < over_end < end:
+                    cuts.add(over_end)
+            bounds = sorted(cuts)
+            for piece_start, piece_end in zip(bounds, bounds[1:]):
+                style = base
+                for over_start, over_end, over_style in overlays:
+                    if over_start <= piece_start and piece_end <= over_end:
+                        style = style + over_style
+                segments.append(
+                    Segment(strip_control_codes(text[piece_start:piece_end]), style)
+                )
+
         return Strip(segments)
 
     # ------------------------------------------------------------------
@@ -462,7 +583,39 @@ class ScrollableTerminal(ScrollView, can_focus=True):
     def notify_style_update(self) -> None:
         self._cached_default_colors = None
         self._cached_selection_style = None
+        self._style_cache.clear()
         super().notify_style_update()
+
+    def _cached_style(self, key: tuple) -> Style:
+        """Return the ``rich.Style`` for a style key, memoized.
+
+        A screenful of a real TUI resolves to a few dozen distinct keys, so a
+        plain dict removes essentially every ``Style`` construction from the
+        render path.
+        """
+        style = self._style_cache.get(key)
+        if style is None:
+            # key[:8] rather than a full unpack: _style_key carries every
+            # non-data Char field, and pyte_patch's `dim` is not rendered.
+            fg, bg, bold, italics, underscore, strikethrough, reverse, blink = key[:8]
+            try:
+                style = Style(
+                    color=self._detect_color(fg),
+                    bgcolor=self._detect_color(bg),
+                    bold=bold,
+                    italic=italics,
+                    underline=underscore,
+                    strike=strikethrough,
+                    reverse=reverse,
+                    blink=blink,
+                )
+            except ColorParseError as error:
+                log.warning("color parse error:", error)
+                style = Style()
+            if len(self._style_cache) >= _MAX_STYLE_CACHE:
+                self._style_cache.clear()
+            self._style_cache[key] = style
+        return style
 
     def _resolved_default_colors(self) -> tuple[str, str]:
         """Return resolved (fg, bg) for default/inherited colors, cached."""
@@ -521,25 +674,7 @@ class ScrollableTerminal(ScrollView, can_focus=True):
 
     def _char_rich_style(self, char: Char) -> Style:
         """Convert a pyte Char's attributes to a ``rich.Style``."""
-        foreground = self._detect_color(char.fg)
-        background = self._detect_color(char.bg)
-
-        try:
-            style = Style(
-                color=foreground,
-                bgcolor=background,
-                bold=char.bold,
-                italic=char.italics,
-                underline=char.underscore,
-                strike=char.strikethrough,
-                reverse=char.reverse,
-                blink=char.blink,
-            )
-        except ColorParseError as error:
-            log.warning("color parse error:", error)
-            style = Style()
-
-        return style
+        return self._cached_style(_style_key(char))
 
     # Keep these as instance methods for MonitoredTerminal compatibility
     # (MonitoredTerminal.recv references self.char_rich_style etc.)

--- a/src/lazyagent/widgets/scrollable_terminal.py
+++ b/src/lazyagent/widgets/scrollable_terminal.py
@@ -24,7 +24,7 @@ from rich.segment import Segment
 from rich.style import Style
 
 from textual import events, log
-from textual.geometry import Offset, Size
+from textual.geometry import Offset, Region, Size
 from textual.scroll_view import ScrollView
 from textual.selection import Selection
 from textual.strip import Strip
@@ -286,6 +286,15 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         # style key (see _style_key) → rich.Style, invalidated on theme change
         self._style_cache: dict[tuple, Style] = {}
 
+        # Partial-repaint bookkeeping (see _refresh_dirty_rows). pyte does not
+        # track the cursor in Screen.dirty, and a scroll invalidates every row.
+        self._last_cursor: tuple[int, int, bool] = (0, 0, False)
+        self._last_scrollback_len: int = 0
+
+        # Per-render-pass hoists (see render_lines). None/-1 when not rendering.
+        self._frame_style: Style | None = None
+        self._frame_width: int = -1
+
         # Key translation table (same as textual-terminal)
         self.ctrl_keys = {
             "up": "\x1bOA",
@@ -418,7 +427,7 @@ class ScrollableTerminal(ScrollView, can_focus=True):
                             log.warning("could not feed:", error)
 
                         self._update_virtual_size()
-                        self.refresh()
+                        self._refresh_dirty_rows()
                         if was_at_bottom:
                             self.scroll_end(
                                 animate=False, immediate=True, x_axis=False
@@ -486,6 +495,7 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         def _restore() -> None:
             self._update_virtual_size()
             self.refresh()
+            self._sync_dirty_state()
             if self._follow_output:
                 self.scroll_end(animate=False, immediate=True, x_axis=False)
 
@@ -502,9 +512,90 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         total_lines = len(self._screen.scrollback) + self._screen.lines
         self.virtual_size = Size(self.ncol, total_lines)
 
+    def _refresh_dirty_rows(self) -> None:
+        """Repaint only the screen rows the last feed actually changed.
+
+        A bare ``refresh()`` clears Textual's per-line strip cache, so every
+        visible row is re-rendered. Agents overwhelmingly emit tiny chunks — a
+        spinner tick, a few streamed tokens — and a real session measured 95%
+        of chunks at under 100 characters, each triggering a full repaint of
+        36 rows. Rendering was 43s against 1.2s of parsing.
+
+        pyte already records which rows changed in ``Screen.dirty``; it is the
+        consumer's job to read and clear it.
+        """
+        screen = self._screen
+        dirty = screen.dirty
+        cursor = screen.cursor
+        # x matters as much as y: the cursor is drawn as a block on one cell,
+        # so sliding it along a row leaves the old cell painted unless that row
+        # is redrawn.
+        cursor_state = (cursor.y, cursor.x, cursor.hidden)
+        scrollback_len = len(screen.scrollback)
+
+        # A scroll shifts every virtual row, so nothing cached is reusable.
+        if scrollback_len != self._last_scrollback_len:
+            self._last_scrollback_len = scrollback_len
+            self._last_cursor = cursor_state
+            dirty.clear()
+            self.refresh()
+            return
+
+        # pyte does not mark a row dirty when only the cursor moved, so both
+        # the row it left and the row it arrived on have to be redrawn.
+        if cursor_state != self._last_cursor:
+            dirty.add(self._last_cursor[0])
+            dirty.add(cursor_state[0])
+            self._last_cursor = cursor_state
+
+        if not dirty:
+            return
+
+        # Past a certain fraction, one whole-widget repaint beats a pile of
+        # single-line regions.
+        if len(dirty) * 2 >= screen.lines:
+            dirty.clear()
+            self.refresh()
+            return
+
+        # Only rows actually on screen are worth a region; refreshing an
+        # off-viewport row still schedules a repaint pass for nothing.
+        top = self.scroll_offset.y
+        bottom = top + self.scrollable_content_region.height
+        for screen_y in dirty:
+            virtual_y = scrollback_len + screen_y
+            if top <= virtual_y < bottom:
+                # refresh_line takes a virtual row and subtracts scroll itself.
+                self.refresh_line(virtual_y)
+        dirty.clear()
+
+    def _sync_dirty_state(self) -> None:
+        """Re-baseline partial-repaint bookkeeping after a full repaint."""
+        screen = self._screen
+        screen.dirty.clear()
+        self._last_cursor = (screen.cursor.y, screen.cursor.x, screen.cursor.hidden)
+        self._last_scrollback_len = len(screen.scrollback)
+
     # ------------------------------------------------------------------
     # Line API rendering
     # ------------------------------------------------------------------
+
+    def render_lines(self, crop: Region) -> list[Strip]:
+        """Render a block of lines, hoisting what is constant for the pass.
+
+        ``rich_style`` walks the DOM ancestor chain and combines styles on
+        every access — measured at ~50µs, against ~35µs for encoding a whole
+        row — and ``scrollable_content_region`` recomputes region arithmetic.
+        Both are fixed for the duration of one render pass but were being
+        recomputed for every line of it.
+        """
+        self._frame_style = self.rich_style
+        self._frame_width = self.scrollable_content_region.width
+        try:
+            return super().render_lines(crop)
+        finally:
+            self._frame_style = None
+            self._frame_width = -1
 
     def render_line(self, y: int) -> Strip:
         """Render a single line.
@@ -513,10 +604,18 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         We add ``scroll_offset.y`` to map into virtual space, then
         dispatch to scrollback or live screen rendering.
         """
+        # Populated by render_lines; fall back for direct calls (tests, and
+        # anything that renders a line outside a full pass).
+        style = self._frame_style
+        if style is None:
+            style = self.rich_style
+        width = self._frame_width
+        if width < 0:
+            width = self.scrollable_content_region.width
+
         scroll_x, scroll_y = self.scroll_offset
         virtual_y = scroll_y + y
         scrollback_len = len(self._screen.scrollback)
-        width = self.scrollable_content_region.width
 
         if virtual_y < scrollback_len:
             strip = self._render_scrollback_line(virtual_y, width, virtual_y)
@@ -524,7 +623,7 @@ class ScrollableTerminal(ScrollView, can_focus=True):
             screen_y = virtual_y - scrollback_len
             strip = self._render_screen_line(screen_y, width, virtual_y)
 
-        return strip.crop_extend(scroll_x, scroll_x + width, self.rich_style)
+        return strip.crop_extend(scroll_x, scroll_x + width, style)
 
     def _render_scrollback_line(self, index: int, width: int, virtual_y: int) -> Strip:
         """Render a line from the scrollback buffer.

--- a/src/lazyagent/widgets/scrollable_terminal.py
+++ b/src/lazyagent/widgets/scrollable_terminal.py
@@ -69,13 +69,91 @@ def _style_key(char: Char) -> tuple:
     return char[1:]
 
 
+def _encode_scrollback_row(
+    row: dict[int, Char],
+    columns: int,
+    default_char: Char,
+    intern: dict[tuple, tuple],
+) -> tuple[str, tuple]:
+    """Encode a pyte row into the compact scrollback representation.
+
+    Returns ``(text, runs)`` where ``runs`` is a tuple of
+    ``(start, end, style_key)`` with offsets into ``text``.
+
+    Trailing cells that are blank *and* default-styled are dropped — the
+    renderer pads short rows back out with exactly those cells, so this is
+    lossless — and style keys are interned, so a screenful of scrolled-off
+    lines shares a handful of key tuples.
+    """
+    if not row:
+        return "", ()
+
+    default_key = _style_key(default_char)
+    get = row.get
+
+    last = -1
+    for x in row:
+        if last < x < columns:
+            last = x
+    while last >= 0:
+        char = get(last)
+        if char is not None and (char[0] != " " or char[1:] != default_key):
+            break
+        last -= 1
+    if last < 0:
+        return "", ()
+
+    parts: list[str] = []
+    runs: list[tuple[int, int, tuple]] = []
+    buf: list[str] = []
+    cur_key: tuple | None = None
+    start = 0
+
+    for x in range(last + 1):
+        char = get(x, default_char)
+        key = char[1:]
+        if key != cur_key:
+            if buf:
+                run = "".join(buf)
+                parts.append(run)
+                end = start + len(run)
+                runs.append((start, end, cur_key))
+                start = end
+                buf.clear()
+            # Interning keeps one key tuple per distinct style instead of one
+            # per run per line. Capped so a truecolor-heavy app cannot grow
+            # the table without bound.
+            cur_key = intern.setdefault(key, key) if len(intern) < _MAX_STYLE_CACHE else key
+        buf.append(char[0])
+
+    if buf:
+        run = "".join(buf)
+        parts.append(run)
+        runs.append((start, start + len(run), cur_key))
+
+    return "".join(parts), tuple(runs)
+
+
 class ScrollbackScreen(pyte.Screen):
     """pyte Screen that captures lines scrolled off the top into a deque.
 
     Only overrides ``index()`` (the method called when the cursor is at the
     bottom margin and a new line is needed).  No ``__getattribute__`` wrapper,
-    no ``before_event``/``after_event``.  Cost: one ``dict()`` copy per line
-    scrolled off.
+    no ``before_event``/``after_event``.
+
+    Scrolled-off lines are stored in the compact form produced by
+    :func:`_encode_scrollback_row` — a ``str`` plus plain tuples of
+    primitives — rather than as a ``dict[int, Char]``.
+
+    **The tuples must stay plain tuples.**  CPython untracks a tuple whose
+    items are all untracked (``_PyTuple_MaybeUntrack``), but it gates that on
+    ``PyTuple_CheckExact``, so a NamedTuple subclass such as pyte's ``Char``
+    is *never* untracked.  Every cell kept as a ``Char`` is therefore
+    traversed by every gen2 collection for as long as it is in scrollback:
+    six terminals with full scrollback measured 583 MB RSS and ~560 ms
+    collection pauses, which the user sees as a freeze.  Swapping these
+    tuples for a NamedTuple or a dataclass would silently bring that back —
+    ``test_scrollback_entries_are_gc_untracked`` guards it.
     """
 
     def __init__(
@@ -85,7 +163,8 @@ class ScrollbackScreen(pyte.Screen):
         max_scrollback: int = _DEFAULT_MAX_SCROLLBACK,
     ) -> None:
         super().__init__(columns, lines)
-        self.scrollback: deque[dict[int, Char]] = deque(maxlen=max_scrollback)
+        self.scrollback: deque[tuple[str, tuple]] = deque(maxlen=max_scrollback)
+        self._style_key_intern: dict[tuple, tuple] = {}
 
     def set_margins(self, *args, **kwargs):
         """TERM=linux compat — strip the ``private`` kwarg that pyte passes."""
@@ -99,8 +178,39 @@ class ScrollbackScreen(pyte.Screen):
             # row 0 (full-screen scroll).  When an app sets custom margins
             # (DECSTBM), lines scrolling within a sub-region should not be
             # saved — matching the behaviour of kitty, xterm, etc.
-            self.scrollback.append(dict(self.buffer[0]))
+            self.scrollback.append(
+                _encode_scrollback_row(
+                    self.buffer[0],
+                    self.columns,
+                    self.default_char,
+                    self._style_key_intern,
+                )
+            )
         super().index()
+
+    # ------------------------------------------------------------------
+    # Text access — used by selection, double/triple click and the IPC
+    # read_agent_output tool, so row→text lives in one place.
+    # ------------------------------------------------------------------
+
+    def scrollback_text(self, index: int) -> str:
+        """Return the text of a scrollback line, trailing blanks stripped."""
+        return self.scrollback[index][0].rstrip()
+
+    def screen_text(self, y: int) -> str:
+        """Return the text of a live screen row, trailing blanks stripped."""
+        row = self.buffer[y]
+        default_char = self.default_char
+        return "".join(
+            row.get(x, default_char).data for x in range(self.columns)
+        ).rstrip()
+
+    def line_text(self, virtual_y: int) -> str:
+        """Return the text of a virtual line (scrollback first, then screen)."""
+        scrollback_len = len(self.scrollback)
+        if virtual_y < scrollback_len:
+            return self.scrollback_text(virtual_y)
+        return self.screen_text(virtual_y - scrollback_len)
 
 
 # ---------------------------------------------------------------------------
@@ -417,9 +527,14 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         return strip.crop_extend(scroll_x, scroll_x + width, self.rich_style)
 
     def _render_scrollback_line(self, index: int, width: int, virtual_y: int) -> Strip:
-        """Render a line from the scrollback buffer."""
-        row = self._screen.scrollback[index]
-        return self._row_to_strip(row, width, show_cursor=False, virtual_y=virtual_y)
+        """Render a line from the scrollback buffer.
+
+        Scrollback is already run-length encoded, so this skips the per-cell
+        pass the live screen needs.
+        """
+        text, runs = self._screen.scrollback[index]
+        ncols = max(width, self._screen.columns)
+        return self._runs_to_strip(text, runs, ncols, virtual_y=virtual_y)
 
     def _render_screen_line(self, screen_y: int, width: int, virtual_y: int) -> Strip:
         """Render a line from the live pyte screen buffer."""
@@ -521,7 +636,13 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         """
         pad = ncols - len(text)
         if pad > 0:
-            runs = [*runs, (len(text), ncols, _style_key(self._screen.default_char))]
+            default_key = _style_key(self._screen.default_char)
+            if runs and runs[-1][2] == default_key:
+                # The stored row already ends in default-styled cells — extend
+                # that run rather than emitting a second identical segment.
+                runs = [*runs[:-1], (runs[-1][0], ncols, default_key)]
+            else:
+                runs = [*runs, (len(text), ncols, default_key)]
             text = text + " " * pad
 
         # Overlays are applied in insertion order, mirroring the order the
@@ -832,18 +953,14 @@ class ScrollableTerminal(ScrollView, can_focus=True):
         text, _ = result
         return text if text else None
 
-    def _row_to_text(self, row_data: dict[int, Char]) -> str:
-        """Convert a pyte row dict to a stripped text line."""
-        return "".join(
-            row_data.get(x, self._screen.default_char).data
-            for x in range(self._screen.columns)
-        ).rstrip()
-
     def _extract_selection(self, selection: Selection) -> tuple[str, str] | None:
         """Extract text from scrollback + screen buffer for a selection."""
-        lines = [self._row_to_text(row) for row in self._screen.scrollback]
-        for y in range(self._screen.lines):
-            lines.append(self._row_to_text(self._screen.buffer[y]))
+        screen = self._screen
+        lines = [
+            screen.scrollback_text(index) for index in range(len(screen.scrollback))
+        ]
+        for y in range(screen.lines):
+            lines.append(screen.screen_text(y))
         full_text = "\n".join(lines)
         return selection.extract(full_text), "\n"
 
@@ -932,18 +1049,10 @@ class ScrollableTerminal(ScrollView, can_focus=True):
     # Double-click / triple-click selection helpers
     # ------------------------------------------------------------------
 
-    def _get_row_at(self, virtual_y: int) -> dict[int, Char]:
-        """Return the row dict for a given virtual y coordinate."""
-        scrollback_len = len(self._screen.scrollback)
-        if virtual_y < scrollback_len:
-            return self._screen.scrollback[virtual_y]
-        return self._screen.buffer[virtual_y - scrollback_len]
-
     def _select_word(self, event: events.Click) -> None:
         """Select the word under the cursor (double-click)."""
         pos = self._mouse_to_virtual(event)
-        row = self._get_row_at(pos.y)
-        line = self._row_to_text(row)
+        line = self._screen.line_text(pos.y)
         x = pos.x
         if x >= len(line) or not line[x].strip():
             return
@@ -959,8 +1068,7 @@ class ScrollableTerminal(ScrollView, can_focus=True):
     def _select_line(self, event: events.Click) -> None:
         """Select the entire line (triple-click)."""
         pos = self._mouse_to_virtual(event)
-        row = self._get_row_at(pos.y)
-        line = self._row_to_text(row)
+        line = self._screen.line_text(pos.y)
         self._sel_start = Offset(0, pos.y)
         self._sel_end = Offset(len(line), pos.y)
         self._update_cached_selection()

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -16,7 +16,11 @@ from lazyagent.models import AgentState, AgentStatus, GitStatus, WorktreeInfo
 from lazyagent.widgets.center_panel import CenterPanel, WorktreePanel
 from lazyagent.widgets.create_worktree_modal import CreateWorktreeResult
 from lazyagent.widgets.remove_worktree_modal import RemoveWorktreeResult
-from lazyagent.widgets.worktree_list import WorktreeList, WorktreeListItem
+from lazyagent.widgets.worktree_list import (
+    OrchestratorListItem,
+    WorktreeList,
+    WorktreeListItem,
+)
 
 
 MAIN_WORKTREE = WorktreeInfo(
@@ -508,3 +512,110 @@ class TestGitStatusRefresh:
             b for b in LazyAgent.BINDINGS
             if isinstance(b, Binding) and b.key == "alt+g"
         ).priority is True
+
+
+class TestGitStatusDebounce:
+    """Moving through the sidebar must not fetch status for every worktree."""
+
+    @pytest.mark.asyncio
+    async def test_passing_through_worktrees_only_polls_the_final_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_app_dependencies(monkeypatch)
+        # Long window so it cannot fire mid-test: what matters is that passing
+        # through *queues* nothing, not how long the window happens to be.
+        monkeypatch.setattr("lazyagent.app._GIT_STATUS_DEBOUNCE", 30.0)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+
+            # Scroll past the first worktree and land on the second.
+            await _select_worktree(app, 0)
+            passed_through = app._git_status_debounce
+            final = await _select_worktree(app, 1)
+
+            # Neither worktree has been fetched yet...
+            assert _status_paths() == set()
+            # ...and the worktree we passed through had its pending fetch
+            # replaced rather than a second one queued alongside it.
+            assert passed_through is not None
+            assert app._git_status_debounce is not passed_through
+
+            # Firing what the timer would call fetches only where we landed.
+            app._refresh_selected_git_status()
+            await _drain_workers(app)
+
+        assert _status_paths() == {final.path}
+
+    @pytest.mark.asyncio
+    async def test_staying_on_a_worktree_polls_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The timer really does fire once the selection settles."""
+        _patch_app_dependencies(monkeypatch)
+        monkeypatch.setattr("lazyagent.app._GIT_STATUS_DEBOUNCE", 0.05)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+
+            wt = await _select_worktree(app, 1)
+            await asyncio.sleep(0.4)
+            await _drain_workers(app)
+
+        assert _status_paths() == {wt.path}
+
+    @pytest.mark.asyncio
+    async def test_leaving_for_the_orchestrator_cancels_the_pending_poll(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_app_dependencies(monkeypatch)
+        monkeypatch.setattr("lazyagent.app._GIT_STATUS_DEBOUNCE", 30.0)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+
+            await _select_worktree(app, 1)
+            assert app._git_status_debounce is not None
+
+            worktree_list = app.query_one(WorktreeList)
+            orchestrator = next(
+                child for child in worktree_list.children
+                if isinstance(child, OrchestratorListItem)
+            )
+            await app.on_list_view_highlighted(
+                WorktreeList.Highlighted(worktree_list, orchestrator)
+            )
+
+            assert app._git_status_debounce is None
+            await _drain_workers(app)
+
+        assert _status_paths() == set()
+
+    @pytest.mark.asyncio
+    async def test_on_demand_refresh_is_not_debounced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Alt+G is an explicit request — it fires immediately."""
+        _patch_app_dependencies(monkeypatch)
+        monkeypatch.setattr("lazyagent.app._GIT_STATUS_DEBOUNCE", 30.0)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            wt = await _select_worktree(app, 1)
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+            app.notify = MagicMock()
+
+            app.action_refresh_git_status()
+            await _drain_workers(app)
+
+            # Fired without waiting out the window...
+            assert _status_paths() == {wt.path}
+            # ...and dropped the pending selection-triggered fetch.
+            assert app._git_status_debounce is None

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import asyncio
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from textual.binding import Binding
 from textual.widgets import TabbedContent
+from textual.worker import WorkerState
 
 from lazyagent.app import LazyAgent
 from lazyagent.config import Config, WorktreeConfig
@@ -49,6 +53,12 @@ def _make_app_with_config(
 
 
 class DummyWorktreeManager:
+    #: (kind, path) for every git call, so tests can assert *which* worktrees
+    #: were touched. Class-level: the app builds its own manager instances.
+    calls: list[tuple[str, str]] = []
+    #: seconds each git call blocks for — used to prove the work is threaded
+    delay: float = 0.0
+
     def __init__(self, repo_path: str | Path) -> None:
         self.repo_path = Path(repo_path)
 
@@ -58,10 +68,24 @@ class DummyWorktreeManager:
     def get_all_git_statuses(
         self, worktrees: list[WorktreeInfo]
     ) -> dict[str, GitStatus]:
+        for wt in worktrees:
+            DummyWorktreeManager.calls.append(("status", wt.path))
+        if DummyWorktreeManager.delay:
+            time.sleep(DummyWorktreeManager.delay)
         return {
             wt.path: GitStatus(last_commit_subject=f"commit for {wt.name}")
             for wt in worktrees
         }
+
+    def get_git_status(self, worktree_path: str | Path) -> GitStatus:
+        DummyWorktreeManager.calls.append(("status", str(worktree_path)))
+        if DummyWorktreeManager.delay:
+            time.sleep(DummyWorktreeManager.delay)
+        return GitStatus()
+
+    def get_last_commit_subject(self, worktree_path: str | Path) -> str:
+        DummyWorktreeManager.calls.append(("subject", str(worktree_path)))
+        return f"commit for {worktree_path}"
 
     @staticmethod
     def get_diff(worktree_path: str) -> str:
@@ -85,6 +109,24 @@ def _patch_app_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
         return None
 
     monkeypatch.setattr(LazyAgent, "_refresh_pr_status", no_pr_refresh)
+
+
+async def _drain_workers(app: LazyAgent) -> None:
+    """Wait for background workers to settle.
+
+    Not ``workers.wait_for_complete()``: these workers use ``exclusive=True``,
+    and that helper re-raises ``WorkerCancelled`` for every worker an exclusive
+    call superseded — which is normal operation here, not a failure.
+    """
+    deadline = time.perf_counter() + 5.0
+    while time.perf_counter() < deadline:
+        if not [
+            w for w in app.workers
+            if w.state in (WorkerState.PENDING, WorkerState.RUNNING)
+        ]:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("workers did not finish within 5s")
 
 
 async def _select_worktree(app: LazyAgent, index: int) -> WorktreeInfo:
@@ -307,3 +349,162 @@ def test_do_create_worktree_no_extra_options() -> None:
     app._send_to_terminal.assert_called_once_with(
         "create-worktree feature/demo repo-feature/demo main /repo-feature/demo /repo"
     )
+
+
+# ---------------------------------------------------------------------------
+# Git status refresh
+# ---------------------------------------------------------------------------
+
+
+def _status_paths() -> set[str]:
+    return {path for kind, path in DummyWorktreeManager.calls if kind == "status"}
+
+
+class TestGitStatusRefresh:
+    @pytest.mark.asyncio
+    async def test_periodic_poll_only_touches_the_selected_worktree(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The timer must not sweep every worktree — that is the expensive part."""
+        _patch_app_dependencies(monkeypatch)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            wt = await _select_worktree(app, 1)
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+
+            app._refresh_selected_git_status()
+            await _drain_workers(app)
+
+        assert _status_paths() == {wt.path}
+
+    @pytest.mark.asyncio
+    async def test_full_rescan_still_covers_every_worktree(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`r` / create / remove / MCP still refresh the whole sidebar."""
+        _patch_app_dependencies(monkeypatch)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+
+            app._load_worktrees()
+            await _drain_workers(app)
+
+            assert set(app._git_statuses) == {wt.path for wt in WORKTREES}
+        assert _status_paths() == {wt.path for wt in WORKTREES}
+
+    @pytest.mark.asyncio
+    async def test_sweep_does_not_block_the_message_pump(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The regression guard: `git status` runs off the event loop.
+
+        Sweeping every worktree took ~3 s on a repo with 22 of them, and it
+        used to run inline — freezing the whole UI twice a minute. If the
+        `@work(thread=True)` decorator is ever dropped, this call blocks for
+        the full delay and the test fails.
+        """
+        _patch_app_dependencies(monkeypatch)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            DummyWorktreeManager.delay = 0.3
+            try:
+                start = time.perf_counter()
+                app._refresh_git_statuses()
+                inline = time.perf_counter() - start
+
+                start = time.perf_counter()
+                app._refresh_selected_git_status()
+                inline_selected = time.perf_counter() - start
+
+                await _drain_workers(app)
+            finally:
+                DummyWorktreeManager.delay = 0.0
+
+        assert inline < 0.1, f"full sweep blocked the pump for {inline:.2f}s"
+        assert inline_selected < 0.1, (
+            f"selected refresh blocked the pump for {inline_selected:.2f}s"
+        )
+
+    @pytest.mark.asyncio
+    async def test_selected_refresh_keeps_other_statuses(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Merging, not replacing: the sidebar must not lose the other badges."""
+        _patch_app_dependencies(monkeypatch)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            app._git_statuses = {
+                MAIN_WORKTREE.path: GitStatus(last_commit_subject="old main"),
+                FEATURE_WORKTREE.path: GitStatus(last_commit_subject="old feature"),
+            }
+
+            app._apply_git_statuses(
+                {FEATURE_WORKTREE.path: GitStatus(last_commit_subject="new feature")}
+            )
+
+            assert app._git_statuses[FEATURE_WORKTREE.path].last_commit_subject == (
+                "new feature"
+            )
+            assert app._git_statuses[MAIN_WORKTREE.path].last_commit_subject == (
+                "old main"
+            )
+
+    @pytest.mark.asyncio
+    async def test_action_refreshes_only_git_status(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Alt+G refreshes the badge without re-listing worktrees."""
+        _patch_app_dependencies(monkeypatch)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            wt = await _select_worktree(app, 1)
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+            app.notify = MagicMock()
+            reload_worktrees = MagicMock()
+            monkeypatch.setattr(LazyAgent, "_load_worktrees", reload_worktrees)
+
+            app.action_refresh_git_status()
+            await _drain_workers(app)
+
+        assert _status_paths() == {wt.path}
+        reload_worktrees.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_action_is_a_noop_without_a_selection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_app_dependencies(monkeypatch)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            app._selected_worktree = None
+            DummyWorktreeManager.calls.clear()
+
+            app.action_refresh_git_status()
+            await _drain_workers(app)
+
+        assert DummyWorktreeManager.calls == []
+
+    def test_binding_is_registered(self) -> None:
+        bindings = {
+            b.key: b.action
+            for b in LazyAgent.BINDINGS
+            if isinstance(b, Binding)
+        }
+        assert bindings["alt+g"] == "refresh_git_status"
+        assert next(
+            b for b in LazyAgent.BINDINGS
+            if isinstance(b, Binding) and b.key == "alt+g"
+        ).priority is True

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -396,6 +396,39 @@ class TestReadAgentOutput:
         result = await server._dispatch("req-1", "read_agent_output", {"worktree_path": "/tmp/repo"})
         assert "error" in result
 
+    @pytest.mark.asyncio
+    async def test_returns_scrollback_and_live_lines(self):
+        """Output spans scrollback history and the live screen, oldest first."""
+        import pyte
+        from lazyagent.widgets.scrollable_terminal import ScrollbackScreen
+
+        screen = ScrollbackScreen(40, 4)
+        stream = pyte.Stream(screen)
+        for i in range(12):
+            stream.feed(f"line {i}\r\n")
+        assert len(screen.scrollback) > 0  # some lines scrolled off
+
+        terminal = MagicMock()
+        terminal._screen = screen
+        panel = MagicMock()
+        panel.agent_ids = ["a1"]
+        panel.get_agent.return_value = terminal
+
+        app = _make_app()
+        mock_center = MagicMock()
+        mock_center.get_panel.return_value = panel
+        app.query_one.return_value = mock_center
+
+        server = IpcServer(app, "/tmp/test.sock")
+        result = await server._dispatch(
+            "req-1", "read_agent_output", {"worktree_path": "/tmp/repo", "lines": 6}
+        )
+
+        lines = result["result"]["lines"]
+        # The trailing "\r\n" leaves the cursor on a blank final row.
+        assert lines == ["line 7", "line 8", "line 9", "line 10", "line 11", ""]
+        assert result["result"]["total_lines"] == len(screen.scrollback) + 4
+
 
 class TestDispatch:
     @pytest.mark.asyncio

--- a/tests/test_multi_agent_panel.py
+++ b/tests/test_multi_agent_panel.py
@@ -44,6 +44,12 @@ class DummyWorktreeManager:
     def get_all_git_statuses(self, worktrees):
         return {wt.path: GitStatus() for wt in worktrees}
 
+    def get_git_status(self, worktree_path):
+        return GitStatus()
+
+    def get_last_commit_subject(self, worktree_path):
+        return ""
+
     @staticmethod
     def get_diff(worktree_path):
         return ""

--- a/tests/test_orchestrator_panel.py
+++ b/tests/test_orchestrator_panel.py
@@ -44,6 +44,12 @@ class DummyWorktreeManager:
     def get_all_git_statuses(self, worktrees):
         return {wt.path: GitStatus() for wt in worktrees}
 
+    def get_git_status(self, worktree_path):
+        return GitStatus()
+
+    def get_last_commit_subject(self, worktree_path):
+        return ""
+
     @staticmethod
     def get_diff(worktree_path):
         return ""

--- a/tests/test_pyte_patch.py
+++ b/tests/test_pyte_patch.py
@@ -384,3 +384,130 @@ class TestRunawayBuffers:
         out = flt.filter("\x1bPpayload\x1b\\after")
         assert "after" in out
         assert flt.state == flt.NORMAL
+
+
+class TestDrawFastPath:
+    """The draw() fast path must be indistinguishable from stock pyte.
+
+    Each case feeds identical input to two screens — one running the patched
+    draw, one running the original — and compares the entire resulting state.
+    The cases deliberately cover everything the fast path bails out of.
+    """
+
+    @staticmethod
+    def _state(screen):
+        return (
+            {y: dict(screen.buffer[y]) for y in range(screen.lines)},
+            screen.cursor.x,
+            screen.cursor.y,
+            sorted(screen.dirty),
+        )
+
+    def _compare(self, feeds, columns=20, lines=4, use_utf8=True):
+        import lazyagent.pyte_patch as pp
+
+        patched = pyte.Screen(columns, lines)
+        stock = pyte.Screen(columns, lines)
+
+        patched_stream = pyte.Stream(patched)
+        patched_stream.use_utf8 = use_utf8
+        for chunk in feeds:
+            patched_stream.feed(chunk)
+
+        original = pyte.screens.Screen.draw
+        pyte.screens.Screen.draw = pp._orig_draw
+        try:
+            stock_stream = pyte.Stream(stock)
+            stock_stream.use_utf8 = use_utf8
+            for chunk in feeds:
+                stock_stream.feed(chunk)
+        finally:
+            pyte.screens.Screen.draw = original
+
+        assert self._state(patched) == self._state(stock)
+        return patched
+
+    def test_plain_ascii(self):
+        self._compare(["hello world"])
+
+    def test_empty_draw(self):
+        self._compare(["\x1b[0m"])
+
+    def test_styled_runs(self):
+        self._compare(["\x1b[1;31mred\x1b[0m \x1b[4;42mgreen\x1b[0m tail"])
+
+    def test_run_exactly_fills_the_line(self):
+        self._compare(["x" * 20])
+
+    def test_run_overflows_the_line(self):
+        """Wrapping is delegated to the original implementation."""
+        self._compare(["y" * 55])
+
+    def test_draw_at_the_right_margin(self):
+        """The pending-wrap state (cursor.x == columns) must still wrap."""
+        self._compare(["\x1b[1;20Hab"])
+
+    def test_autowrap_disabled(self):
+        self._compare(["\x1b[?7l", "z" * 40])
+
+    def test_insert_mode(self):
+        """IRM shifts existing cells right — never the fast path."""
+        self._compare(["abcdef", "\x1b[1;3H", "\x1b[4h", "XY"])
+
+    def test_vt100_box_drawing_charset(self):
+        r"""\e(0 remaps ASCII to box drawing; the translate pass is required.
+
+        pyte ignores charset selection while ``use_utf8`` is set (the default
+        for ``pyte.Stream``), so this drives it with ``use_utf8=False`` to
+        actually reach the branch the fast path bails out of.
+        """
+        screen = self._compare(["\x1b(0qqlkmj\x1b(B"], use_utf8=False)
+        # Sanity: the mapping really did happen (not just "both are wrong")
+        assert screen.buffer[0][0].data == "─"
+
+    def test_g1_charset_via_shift_out(self):
+        screen = self._compare(["\x1b)0\x0eqqq\x0f"], use_utf8=False)
+        assert screen.buffer[0][0].data == "─"
+
+    def test_charset_selection_ignored_under_utf8(self):
+        """Documents why the charset guard rarely fires in lazyagent.
+
+        ``pyte.Stream`` defaults to ``use_utf8=True``, under which both SCS
+        (``\\e(0``) and SO/SI are dropped — the active map stays Latin-1. The
+        guard stays in place because the fast path must not depend on a flag
+        set somewhere else.
+        """
+        screen = self._compare(["\x1b(0qqq"])
+        assert screen.buffer[0][0].data == "q"
+
+    def test_wide_characters(self):
+        """CJK is two cells wide and leaves a stub — not the fast path."""
+        self._compare(["你好 ok"])
+
+    def test_combining_characters(self):
+        """Combining marks merge into the preceding cell."""
+        self._compare(["éclair"])
+
+    def test_non_ascii_latin1(self):
+        self._compare(["heló wörld"])
+
+    def test_del_character_is_not_printable(self):
+        self._compare(["ab\x7fcd"])
+
+    def test_mixed_stream(self):
+        self._compare([
+            "\x1b[2J\x1b[H",
+            "\x1b[1;36mplain ascii line\x1b[0m\r\n",
+            "你好 wide\r\n",
+            "\x1b(0qqqq\x1b(B\r\n",
+            "tail" * 12,
+        ])
+
+    def test_repeated_characters_share_one_char_object(self):
+        """The per-call cache shares cells; Char is immutable so this is safe."""
+        screen = pyte.Screen(20, 2)
+        pyte.Stream(screen).feed("aaab")
+        assert screen.buffer[0][0] is screen.buffer[0][1]
+        assert screen.buffer[0][0] is not screen.buffer[0][3]
+        assert screen.buffer[0][0].data == "a"
+        assert screen.buffer[0][3].data == "b"

--- a/tests/test_scrollable_terminal.py
+++ b/tests/test_scrollable_terminal.py
@@ -106,6 +106,7 @@ def _make_scrollable_terminal() -> ScrollableTerminal:
     terminal.stream = pyte.Stream(terminal._screen)
     terminal.ctrl_keys = {}
     terminal._cached_default_colors = None
+    terminal._style_cache = {}
     return terminal
 
 
@@ -142,6 +143,11 @@ class TestAfterStdoutProcessedHook:
         t._after_stdout_processed()  # Should not raise
 
 
+def _cells(strip) -> list[tuple[str, Style]]:
+    """Flatten a Strip into one (character, style) pair per rendered cell."""
+    return [(ch, segment.style) for segment in strip for ch in segment.text]
+
+
 class TestRowToStrip:
     def test_render_default_char_row(self):
         """Rendering a row of default chars produces a strip."""
@@ -157,6 +163,137 @@ class TestRowToStrip:
             strip = t._row_to_strip(row, 80)
             assert strip is not None
             assert strip.cell_length > 0
+
+    def test_row_is_run_length_encoded(self):
+        """Cells sharing a style collapse into a single segment."""
+        t = _make_scrollable_terminal()
+        t.stream.feed("\x1b[31mred\x1b[0mplain")
+
+        strip = t._row_to_strip(t._screen.buffer[0], 80)
+        segments = list(strip)
+
+        assert segments[0].text == "red"
+        assert segments[0].style.color.name == "red"
+        # "plain" plus the default-styled remainder of the row
+        assert segments[1].text.startswith("plain")
+        assert len(segments) == 2
+
+    def test_styles_match_source_chars(self):
+        """Every rendered cell carries the style of its own pyte Char."""
+        t = _make_scrollable_terminal()
+        t.stream.feed("\x1b[1;31ma\x1b[0m\x1b[4;32mb\x1b[0mc")
+
+        cells = _cells(t._row_to_strip(t._screen.buffer[0], 80))
+
+        assert cells[0][0] == "a"
+        assert cells[0][1].color.name == "red"
+        assert cells[0][1].bold is True
+        assert cells[1][0] == "b"
+        assert cells[1][1].color.name == "green"
+        assert cells[1][1].underline is True
+        assert cells[2][0] == "c"
+        assert cells[2][1].bold is not True
+
+    def test_cursor_style_overrides_char_style(self):
+        """The cursor cell keeps its char attributes but swaps fg/bg."""
+        t = _make_scrollable_terminal()
+        t.stream.feed("\x1b[1;31;44mabc")
+        t._screen.cursor.x = 1
+        t._screen.cursor.y = 0
+
+        cells = _cells(t._row_to_strip(t._screen.buffer[0], 80, show_cursor=True))
+
+        # Cursor is applied after character styles: fg/bg swapped, bold kept.
+        assert cells[1][0] == "b"
+        assert cells[1][1].color.name == "blue"
+        assert cells[1][1].bgcolor.name == "red"
+        assert cells[1][1].bold is True
+        # Neighbours are untouched
+        assert cells[0][1].color.name == "red"
+        assert cells[2][1].color.name == "red"
+
+    def test_cursor_at_last_column(self):
+        """A cursor on the final column still renders swapped."""
+        t = _make_scrollable_terminal()
+        t._screen.cursor.x = 79
+        t._screen.cursor.y = 0
+        t._cached_default_colors = ("white", "black")
+
+        cells = _cells(t._row_to_strip(t._screen.buffer[0], 80, show_cursor=True))
+
+        assert cells[79][1].color.name == "black"
+        assert cells[79][1].bgcolor.name == "white"
+
+    def test_selection_style_applied_over_char_style(self):
+        """Selected cells combine the selection style on top of char style."""
+        from textual.geometry import Offset
+
+        t = _make_scrollable_terminal()
+        t.stream.feed("\x1b[31mhello world")
+        t._cached_selection_style = Style(bgcolor="blue")
+        t._sel_start = Offset(0, 0)
+        t._sel_end = Offset(5, 0)
+        t._update_cached_selection()
+
+        cells = _cells(t._row_to_strip(t._screen.buffer[0], 80, virtual_y=0))
+
+        # Inside the selection: char fg preserved, selection bg applied
+        assert cells[0][1].color.name == "red"
+        assert cells[0][1].bgcolor.name == "blue"
+        assert cells[4][1].bgcolor.name == "blue"
+        # Outside the selection: untouched
+        assert cells[5][1].bgcolor.name == "default"
+
+    def test_selection_and_cursor_on_same_row(self):
+        """Selection wins over the cursor where they overlap, as before."""
+        from textual.geometry import Offset
+
+        t = _make_scrollable_terminal()
+        t.stream.feed("hello")
+        t._cached_default_colors = ("white", "black")
+        t._cached_selection_style = Style(bgcolor="blue")
+        t._screen.cursor.x = 1
+        t._screen.cursor.y = 0
+        t._sel_start = Offset(0, 0)
+        t._sel_end = Offset(3, 0)
+        t._update_cached_selection()
+
+        cells = _cells(
+            t._row_to_strip(t._screen.buffer[0], 80, show_cursor=True, virtual_y=0)
+        )
+
+        # Cursor cell is inside the selection — selection bg is applied last
+        assert cells[1][1].bgcolor.name == "blue"
+        # ...but the cursor's fg swap survives (selection only sets bgcolor)
+        assert cells[1][1].color.name == "black"
+
+
+class TestStyleCache:
+    def test_style_is_memoized_per_key(self):
+        """The same style key resolves to the identical Style object."""
+        t = _make_scrollable_terminal()
+        c1 = Char("a", "red", "default", True, False, False, False, False, False)
+        c2 = Char("z", "red", "default", True, False, False, False, False, False)
+
+        assert t._char_rich_style(c1) is t._char_rich_style(c2)
+        assert len(t._style_cache) == 1
+
+    def test_notify_style_update_clears_style_cache(self):
+        """Theme changes drop cached styles alongside the other style state."""
+        t = _make_scrollable_terminal()
+        t._char_rich_style(Char("a", "red"))
+        assert t._style_cache
+
+        with patch.object(type(t).__mro__[1], "notify_style_update", lambda self: None):
+            t.notify_style_update()
+
+        assert t._style_cache == {}
+
+    def test_bad_color_falls_back_to_empty_style(self):
+        """A colour rich cannot parse degrades to a blank style, not a crash."""
+        t = _make_scrollable_terminal()
+        style = t._char_rich_style(Char("a", "not-a-color"))
+        assert style == Style()
 
 
 class TestStyleHelpers:

--- a/tests/test_scrollable_terminal.py
+++ b/tests/test_scrollable_terminal.py
@@ -1,6 +1,7 @@
 """Tests for ScrollbackScreen and ScrollableTerminal."""
 from __future__ import annotations
 
+import gc
 from unittest.mock import MagicMock, patch
 
 import pyte
@@ -27,11 +28,7 @@ class TestScrollbackScreen:
 
         # First line ("line 0") should be in scrollback
         assert len(screen.scrollback) >= 1
-        first_line = "".join(
-            screen.scrollback[0].get(x, screen.default_char).data
-            for x in range(80)
-        ).rstrip()
-        assert first_line.startswith("line 0")
+        assert screen.scrollback_text(0).startswith("line 0")
 
     def test_index_no_capture_when_not_at_bottom(self):
         """No scrollback capture when cursor isn't at the bottom margin."""
@@ -76,6 +73,114 @@ class TestScrollbackScreen:
         screen = ScrollbackScreen(80, 24)
         # Should not raise
         screen.set_margins(0, 23, private=True)
+
+    def test_oldest_line_is_evicted_first(self):
+        """Eviction is FIFO — the surviving lines are the most recent ones."""
+        screen = ScrollbackScreen(80, 2, max_scrollback=3)
+        stream = pyte.Stream(screen)
+
+        for i in range(8):
+            stream.feed(f"line {i}\r\n")
+
+        texts = [screen.scrollback_text(i) for i in range(len(screen.scrollback))]
+        assert texts == ["line 4", "line 5", "line 6"]
+
+
+class TestScrollbackEncoding:
+    """The compact ``(text, runs)`` representation of scrolled-off lines."""
+
+    @staticmethod
+    def _screen_with(*feeds: str, columns: int = 20) -> ScrollbackScreen:
+        """Feed lines through a 2-row screen so the first one scrolls off."""
+        screen = ScrollbackScreen(columns, 2)
+        stream = pyte.Stream(screen)
+        for chunk in feeds:
+            stream.feed(chunk)
+        return screen
+
+    def test_round_trip_text_and_styles(self):
+        """Text and per-run styles survive the trip into scrollback."""
+        screen = self._screen_with("\x1b[31mred\x1b[0m plain\r\n", "second\r\n")
+
+        text, runs = screen.scrollback[0]
+        assert text == "red plain"
+        assert [(start, end) for start, end, _ in runs] == [(0, 3), (3, 9)]
+        assert runs[0][2][0] == "red"  # fg of the styled run
+        assert runs[1][2][0] == "default"
+
+    def test_attributes_round_trip(self):
+        """Bold/underline/reverse and background survive too."""
+        screen = self._screen_with("\x1b[1;4;7;44mx\r\n", "second\r\n")
+
+        _, runs = screen.scrollback[0]
+        fg, bg, bold, italics, underscore, _strike, reverse, _blink = runs[0][2][:8]
+        assert (bg, bold, underscore, reverse) == ("blue", True, True, True)
+
+    def test_trailing_blanks_are_dropped(self):
+        """Unwritten/blank tail cells are not stored — the renderer re-pads."""
+        screen = self._screen_with("hi\r\n", "second\r\n")
+
+        text, runs = screen.scrollback[0]
+        assert text == "hi"
+        assert len(runs) == 1
+
+    def test_gaps_are_filled_with_default_cells(self):
+        """A cursor jump leaves unwritten cells; they encode as default blanks."""
+        screen = self._screen_with("a\x1b[1;5Hb\r\n", "second\r\n")
+
+        text, _ = screen.scrollback[0]
+        assert text == "a   b"
+
+    def test_blank_line_encodes_empty(self):
+        """A line with nothing on it costs a bare empty entry."""
+        screen = self._screen_with("\r\n", "second\r\n")
+        assert screen.scrollback[0] == ("", ())
+
+    def test_scrollback_entries_are_gc_untracked(self):
+        """Scrollback must never hold GC-tracked containers.
+
+        pyte's ``Char`` is a NamedTuple *subclass*, and CPython only untracks
+        tuples that pass ``PyTuple_CheckExact`` — so storing Chars keeps every
+        cell in scrollback tracked forever, and each gen2 collection walks all
+        of them (measured: ~560 ms pauses with six full terminals).  Plain
+        tuples of primitives get untracked and cost nothing.
+
+        This asserts the property, not the implementation: swapping the tuples
+        for a NamedTuple or dataclass "for readability" would reintroduce the
+        pauses silently, and this test is what catches it.
+        """
+        screen = ScrollbackScreen(40, 2)
+        stream = pyte.Stream(screen)
+        for i in range(30):
+            stream.feed(f"\x1b[3{i % 8}mline {i}\x1b[0m\r\n")
+        assert len(screen.scrollback) > 10
+
+        # Untracking cascades one nesting level per collection (a tuple is
+        # only untracked once its items already are), so collect a few times.
+        for _ in range(4):
+            gc.collect()
+
+        for entry in screen.scrollback:
+            assert not gc.is_tracked(entry)
+            text, runs = entry
+            assert not gc.is_tracked(runs)
+            for run in runs:
+                assert not gc.is_tracked(run)
+                assert not gc.is_tracked(run[2])
+                # Exact tuples only — a subclass would never untrack.
+                assert type(run) is tuple
+                assert type(run[2]) is tuple
+
+    def test_style_keys_are_interned(self):
+        """Lines sharing a style share one key tuple, not one per line."""
+        screen = ScrollbackScreen(40, 2)
+        stream = pyte.Stream(screen)
+        for i in range(20):
+            stream.feed(f"\x1b[31mline {i}\x1b[0m\r\n")
+
+        keys = {id(run[2]) for _, runs in screen.scrollback for run in runs}
+        assert len(keys) == len(screen._style_key_intern)
+        assert len(keys) <= 2  # "red" and the default trailing style
 
 
 # ---------------------------------------------------------------------------
@@ -266,6 +371,55 @@ class TestRowToStrip:
         assert cells[1][1].bgcolor.name == "blue"
         # ...but the cursor's fg swap survives (selection only sets bgcolor)
         assert cells[1][1].color.name == "black"
+
+
+class TestRenderScrollbackLine:
+    def test_matches_live_screen_rendering(self):
+        """A line renders the same before and after it scrolls off."""
+        t = _make_scrollable_terminal()
+        t.stream.feed("\x1b[1;31mred\x1b[0m \x1b[4;32mgreen\x1b[0m tail")
+
+        live = _cells(t._row_to_strip(t._screen.buffer[0], 80))
+
+        # Push the line into scrollback
+        for _ in range(6):
+            t.stream.feed("\r\n")
+        assert t._screen.scrollback_text(0) == "red green tail"
+
+        scrolled = _cells(t._render_scrollback_line(0, 80, -1))
+        assert scrolled == live
+
+    def test_short_line_is_padded_to_full_width(self):
+        """Dropped trailing blanks come back as default-styled padding."""
+        t = _make_scrollable_terminal()
+        t.stream.feed("hi")
+        for _ in range(6):
+            t.stream.feed("\r\n")
+
+        cells = _cells(t._render_scrollback_line(0, 80, -1))
+        assert len(cells) == 80
+        assert "".join(ch for ch, _ in cells).rstrip() == "hi"
+        assert cells[40][1] == t._char_rich_style(t._screen.default_char)
+
+    def test_selection_highlights_scrollback_line(self):
+        """Selection spans apply to scrollback rows as well as live ones."""
+        from textual.geometry import Offset
+
+        t = _make_scrollable_terminal()
+        t.stream.feed("\x1b[31mhello world")
+        for _ in range(6):
+            t.stream.feed("\r\n")
+        t._cached_selection_style = Style(bgcolor="blue")
+        t._sel_start = Offset(0, 0)
+        t._sel_end = Offset(5, 0)
+        t._update_cached_selection()
+
+        cells = _cells(t._render_scrollback_line(0, 80, 0))
+
+        assert cells[0][1].color.name == "red"
+        assert cells[0][1].bgcolor.name == "blue"
+        assert cells[4][1].bgcolor.name == "blue"
+        assert cells[5][1].bgcolor.name != "blue"
 
 
 class TestStyleCache:
@@ -557,43 +711,40 @@ class TestResolvedDefaultColors:
 
 
 # ---------------------------------------------------------------------------
-# _get_row_at tests
+# line_text tests
 # ---------------------------------------------------------------------------
 
 
-class TestGetRowAt:
+class TestLineText:
     def test_returns_screen_buffer_row(self):
-        """_get_row_at returns a screen buffer row when no scrollback."""
+        """line_text returns a screen buffer row when no scrollback."""
         t = _make_scrollable_terminal()
         t.stream.feed("hello")
-        row = t._get_row_at(0)
-        text = "".join(
-            row.get(x, t._screen.default_char).data for x in range(5)
-        )
-        assert text == "hello"
+        assert t._screen.line_text(0) == "hello"
 
     def test_returns_scrollback_row(self):
-        """_get_row_at returns a scrollback row for indices within scrollback."""
+        """line_text returns a scrollback row for indices within scrollback."""
         t = _make_scrollable_terminal()
         for i in range(10):
             t.stream.feed(f"line {i}\n")
-        scrollback_len = len(t._screen.scrollback)
-        assert scrollback_len > 0
-        row = t._get_row_at(0)
-        text = "".join(
-            row.get(x, t._screen.default_char).data for x in range(6)
-        ).rstrip()
-        assert text.startswith("line")
+        assert len(t._screen.scrollback) > 0
+        assert t._screen.line_text(0) == "line 0"
 
     def test_returns_screen_row_after_scrollback(self):
-        """_get_row_at returns screen row for indices past scrollback."""
+        """line_text returns a screen row for indices past scrollback."""
         t = _make_scrollable_terminal()
         for i in range(10):
             t.stream.feed(f"line {i}\n")
         scrollback_len = len(t._screen.scrollback)
         # First screen row is at virtual_y == scrollback_len
-        row = t._get_row_at(scrollback_len)
-        assert row is t._screen.buffer[0]
+        assert t._screen.line_text(scrollback_len) == t._screen.screen_text(0)
+
+    def test_trailing_whitespace_is_stripped(self):
+        """Both halves strip trailing blanks, as the old row→text did."""
+        t = _make_scrollable_terminal()
+        for i in range(10):
+            t.stream.feed(f"line {i}   \n")
+        assert t._screen.line_text(0) == "line 0"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scrollable_terminal.py
+++ b/tests/test_scrollable_terminal.py
@@ -212,6 +212,10 @@ def _make_scrollable_terminal() -> ScrollableTerminal:
     terminal.ctrl_keys = {}
     terminal._cached_default_colors = None
     terminal._style_cache = {}
+    terminal._last_cursor = (0, 0, False)
+    terminal._last_scrollback_len = 0
+    terminal._frame_style = None
+    terminal._frame_width = -1
     return terminal
 
 
@@ -870,3 +874,174 @@ class TestSelectLine:
         assert t._sel_start == Offset(0, 0)
         assert t._sel_end is not None
         assert t._sel_end.x > 0  # line has content
+
+
+class TestPartialRepaint:
+    """Only the rows a chunk actually changed should be repainted.
+
+    A bare refresh() clears Textual's per-line strip cache, so every visible
+    row re-renders. Agents mostly emit tiny chunks — a real session logged 95%
+    under 100 characters, each repainting 36 rows — so this is the difference
+    between ~42 and ~2 rendered lines per chunk.
+    """
+
+    @staticmethod
+    def _prepare(t, height=10, scroll_y=0):
+        """Wire up the geometry _refresh_dirty_rows needs, and record calls."""
+        from textual.geometry import Offset, Region, Size
+
+        t.refresh = MagicMock()
+        t.refresh_line = MagicMock()
+        patchers = [
+            patch.object(
+                type(t), "scroll_offset",
+                new_callable=lambda: property(lambda self: Offset(0, scroll_y)),
+            ),
+            patch.object(
+                type(t), "scrollable_content_region",
+                new_callable=lambda: property(
+                    lambda self: Region(0, 0, 80, height)
+                ),
+            ),
+        ]
+        for p in patchers:
+            p.start()
+        return patchers
+
+    @staticmethod
+    def _stop(patchers):
+        for p in patchers:
+            p.stop()
+
+    def test_only_changed_rows_are_refreshed(self):
+        t = _make_scrollable_terminal()
+        t._screen = ScrollbackScreen(80, 10)
+        t.stream = pyte.Stream(t._screen)
+        patchers = self._prepare(t)
+        try:
+            t.stream.feed("\x1b[3;1H")        # park the cursor on row 2 first
+            t._sync_dirty_state()
+            t.stream.feed("hello")            # touches row 2 only
+            t._refresh_dirty_rows()
+        finally:
+            self._stop(patchers)
+
+        t.refresh.assert_not_called()
+        refreshed = {call.args[0] for call in t.refresh_line.call_args_list}
+        assert refreshed == {2}
+
+    def test_cursor_move_within_a_row_repaints_it(self):
+        """The cursor is a block on one cell; pyte does not mark that dirty."""
+        t = _make_scrollable_terminal()
+        t._screen = ScrollbackScreen(80, 10)
+        t.stream = pyte.Stream(t._screen)
+        patchers = self._prepare(t)
+        try:
+            t.stream.feed("\x1b[5;5H")
+            t._sync_dirty_state()
+            t.stream.feed("\x1b[5;40H")       # same row, different column
+            t._refresh_dirty_rows()
+        finally:
+            self._stop(patchers)
+
+        refreshed = {call.args[0] for call in t.refresh_line.call_args_list}
+        assert refreshed == {4}
+
+    def test_cursor_move_between_rows_repaints_both(self):
+        t = _make_scrollable_terminal()
+        t._screen = ScrollbackScreen(80, 10)
+        t.stream = pyte.Stream(t._screen)
+        patchers = self._prepare(t)
+        try:
+            t.stream.feed("\x1b[2;1H")
+            t._sync_dirty_state()
+            t.stream.feed("\x1b[7;1H")
+            t._refresh_dirty_rows()
+        finally:
+            self._stop(patchers)
+
+        refreshed = {call.args[0] for call in t.refresh_line.call_args_list}
+        assert refreshed == {1, 6}
+
+    def test_cursor_visibility_toggle_repaints_the_row(self):
+        t = _make_scrollable_terminal()
+        t._screen = ScrollbackScreen(80, 10)
+        t.stream = pyte.Stream(t._screen)
+        patchers = self._prepare(t)
+        try:
+            t.stream.feed("\x1b[4;1H")
+            t._sync_dirty_state()
+            t.stream.feed("\x1b[?25l")
+            t._refresh_dirty_rows()
+        finally:
+            self._stop(patchers)
+
+        refreshed = {call.args[0] for call in t.refresh_line.call_args_list}
+        assert 3 in refreshed
+
+    def test_scrolling_falls_back_to_a_full_repaint(self):
+        """Scrollback growth shifts every virtual row — nothing is reusable."""
+        t = _make_scrollable_terminal()
+        t._screen = ScrollbackScreen(80, 3)
+        t.stream = pyte.Stream(t._screen)
+        patchers = self._prepare(t)
+        try:
+            t._sync_dirty_state()
+            for i in range(6):
+                t.stream.feed(f"line {i}\r\n")
+            assert len(t._screen.scrollback) > 0
+            t._refresh_dirty_rows()
+        finally:
+            self._stop(patchers)
+
+        t.refresh.assert_called_once()
+        t.refresh_line.assert_not_called()
+
+    def test_widespread_changes_fall_back_to_a_full_repaint(self):
+        """Past half the screen, one repaint beats a pile of line regions."""
+        t = _make_scrollable_terminal()
+        t._screen = ScrollbackScreen(80, 10)
+        t.stream = pyte.Stream(t._screen)
+        patchers = self._prepare(t)
+        try:
+            t._sync_dirty_state()
+            for row in range(1, 9):
+                t.stream.feed(f"\x1b[{row};1Hrow {row}")
+            t._refresh_dirty_rows()
+        finally:
+            self._stop(patchers)
+
+        t.refresh.assert_called_once()
+        t.refresh_line.assert_not_called()
+
+    def test_offscreen_rows_are_not_refreshed(self):
+        """A row scrolled out of view needs no repaint pass scheduled."""
+        t = _make_scrollable_terminal()
+        t._screen = ScrollbackScreen(80, 20)
+        t.stream = pyte.Stream(t._screen)
+        patchers = self._prepare(t, height=5, scroll_y=0)
+        try:
+            t.stream.feed("\x1b[18;1H")   # cursor already below the fold
+            t._sync_dirty_state()
+            t.stream.feed("way below the fold")
+            t._refresh_dirty_rows()
+        finally:
+            self._stop(patchers)
+
+        t.refresh_line.assert_not_called()
+
+    def test_dirty_set_is_consumed(self):
+        """pyte expects the consumer to clear Screen.dirty."""
+        t = _make_scrollable_terminal()
+        t._screen = ScrollbackScreen(80, 10)
+        t.stream = pyte.Stream(t._screen)
+        patchers = self._prepare(t)
+        try:
+            t._sync_dirty_state()
+            t.stream.feed("\x1b[2;1Hx")
+            assert t._screen.dirty
+            t._refresh_dirty_rows()
+        finally:
+            self._stop(patchers)
+
+        assert not t._screen.dirty


### PR DESCRIPTION
> **Contains #45.** `fix-git-status-refresh` is merged into this branch so everything can be tested together. #45 is the same two commits and will close itself when this lands.

Three pure-performance fixes to the terminal hot path. No feature or behaviour change intended; the one visible difference is a pre-existing bug the rewrite stops reproducing (documented below).

Profiled against the real `ScrollableTerminal` in a headless Textual app, 200x40 screen, an Ink-style producer emitting ~20 full-screen repaints/sec (what Claude Code does).

| | |
|---|---|
| **1. Run-length encoded render path** | `_row_to_strip` was 53% of the widget's CPU |
| **2. Compact scrollback storage** | scrollback was GC-tracked forever → ~560 ms freezes |
| **3. Plain-ASCII fast path in `pyte.Screen.draw`** | parsing was 84% of what remained after 1 and 2 |
| **4. Git status off the message pump** (from #45) | a ~3 s full-UI freeze twice a minute |

## Fix 1 — run-length encoded render path

`_row_to_strip` built a `rich.Text` one character at a time: two `dict.get`, a `Text.append`, an eight-field style compare and a fresh `rich.Style` per cell, then `text.render(console)`. That was **53% of the widget's CPU** (4.39s of 8.2s).

Now a single pass emits `rich.Segment`s directly, with a per-widget `Style` cache keyed by the `Char`'s style fields — a real screen resolves to **39 distinct styles**, so essentially every `Style` construction leaves the render path. The key is a plain tuple slice of the `Char` (`char[1:]`), which is one C-level op instead of eight attribute loads, and doubles as the storage key for Fix 2.

Cursor and selection are applied as overlays on top of the runs, in the same order the old code called `Text.stylize()` in, so the cursor's fg/bg swap still wins over character styles and the selection still wins over both. Cache is cleared in `notify_style_update` alongside the other cached style state.

## Fix 2 — compact scrollback storage

`ScrollbackScreen.index()` kept every scrolled-off line as a `dict[int, Char]`. pyte's `Char` is a **NamedTuple subclass**, and CPython's tuple-untracking optimisation (`_PyTuple_MaybeUntrack`) gates on `PyTuple_CheckExact` — so a NamedTuple subclass is *never* untracked. Every cell in scrollback stays GC-tracked forever and is traversed by every gen2 collection. Measured: a `Char` costs **12x** a plain tuple in GC traversal, and six terminals with full scrollback produced ~560 ms full-collection pauses — a user-visible freeze.

Lines are now stored as `(text, runs)`: a `str` plus plain tuples of `(start, end, style_key)`, style keys interned per screen, trailing blank cells dropped (the renderer re-pads them). Plain exact tuples of primitives *do* get untracked, so full scrollback costs the GC essentially nothing. Rendering a scrollback line replays the runs directly, skipping the per-cell pass entirely.

Row→text moved onto `ScrollbackScreen` (`scrollback_text` / `screen_text` / `line_text`) so selection, double/triple-click and `ipc.read_agent_output` share one implementation instead of each walking row dicts.

**`_DEFAULT_MAX_SCROLLBACK` stays at 5000.** The compact form lands ~7x under the memory target on its own, so there was no reason to shorten history.

## Fix 3 — plain-ASCII fast path in `pyte.Screen.draw`

With 1 and 2 in place, parsing was **84% of the remaining per-frame cost**, and `Screen.draw` was ~78% of that. For every single character pyte calls `wcwidth`, tests DECAWM and IRM, re-reads `self.cursor` and `self.buffer`, and builds the cell with `Char._replace` — a NamedTuple `_replace` is ~10x the cost of the tuple construction it wraps (275k `_replace` calls per 60 repaints).

`pyte_patch.py` now adds a fast path for a run of **printable ASCII that fits before the right margin**. Printable ASCII is exactly the set of characters that are unconditionally one cell wide, so no `wcwidth` call is needed at all. Everything the general path exists for is excluded up front and delegated to the original: wrapping and the pending-wrap state (`cursor.x == columns`), insert mode, a non-Latin-1 active charset (`\e(0` remaps ASCII to VT100 box drawing, so the translate pass is *not* optional), wide characters, combining marks, and unprintables.

Within one `draw()` call the cursor attributes cannot change, so cells differ only in their `data`. Each distinct character is built once and the `Char` is shared — it is immutable, and sharing also cuts allocation in the live screen buffer.

## Fix 4 — git status off the message pump (merged from #45)

Found while profiling the lag above, and it turned out to dominate everything else here by three orders of magnitude. `_refresh_git_statuses` ran **on the message pump**, shelling out twice per worktree, serially, for every worktree, every 30 seconds. On a repo with 22 worktrees that is **2.8–3.7 s per sweep — roughly six seconds of every minute with the app unable to process a keystroke**. It also fired on startup, on `r`, on create/remove, and on every MCP worktree change.

| | before | after |
|---|---|---|
| UI blocked per sweep | 2.8–3.7 s | **0** (worker thread) |
| poll frequency | 2/min | 1/min |
| worktrees polled on the timer | all 22 | **1** (selected) |
| git subprocesses/min | 88 | **2** |

- Both sweeps now run in worker threads, applying results on the main thread via `call_from_thread`.
- The timer polls only the selected worktree. The full sweep stays on the rescan paths, which the sidebar needs.
- Selection changes refresh the newly-selected worktree, **debounced by 0.4 s** so scrolling with `j`/`k` doesn't fetch status for every worktree passed through. `exclusive=True` cancels *waiting* on a superseded fetch but can't interrupt a subprocess already running, so the throttle happens before the worker spawns.
- `_git_statuses` merges rather than replaces, so a single-worktree refresh can't blank the other badges.
- **`Alt+G`** refreshes the selected worktree's git status on demand — status only, no worktree re-list. `priority=True`, so it works while a terminal pane has focus.

Regression guard: `test_sweep_does_not_block_the_message_pump` makes the fake git calls sleep and asserts the call returns immediately. Verified it fails with the decorators removed, as do the debounce tests with the debounce bypassed.

## Measurements

Commands (benchmarks live outside the repo and are not committed):

```
uv run python bench_opt.py            # 40-row render, current vs new
uv run python bench_growth.py         # scrollback RSS + gen2 pause as it fills
uv run python bench_gc.py             # Char-untracking mechanism
uv run python bench_longconv.py       # does anything scale with history length?
uv run python bench_frame.py <src>    # deterministic per-frame CPU, one src per run
uv run python profile_app.py 8 1      # end-to-end cProfile, 1 streaming terminal
```

### Per-frame cost — the headline

Fixed workload, identical bytes for every configuration, CPU time, **min of 4 interleaved runs** (the box was busy; interleaving and taking minima keeps the comparison fair):

| workload | base | +fix 1&2 | +fix 3 | total |
|---|---|---|---|---|
| live repaint: ingest + render 40 rows | 46.95 ms | 13.36 ms | **6.27 ms** | **7.5x** |
| scrolled-back view: render 40 rows | 47.73 ms | 13.40 ms | **4.77 ms** | **10.0x** |
| max sustainable full repaints/sec | 21 | 75 | **159** | |

### Components

| metric | before | after |
|---|---|---|
| `_row_to_strip`, 40 rows | 10.51 ms | **1.38 ms** (7.6x) |
| render 40 scrollback rows | 9.59 ms | **0.19 ms** (50x) |
| pyte parse, per 5.6 KB repaint chunk | 8.62 ms | **2.52 ms** (3.4x) |
| `_StreamFilter.filter`, same chunk | 0.48 ms | unchanged |

### Scrollback memory + GC (5000 lines x 200 cols)

| scrollback | RSS before | RSS after | gen2 before | gen2 after |
|---|---|---|---|---|
| empty | 37.3 MB | 37.3 MB | 6.8 ms | 5.7 ms |
| 5000 lines, 1 terminal | 128.6 MB | **40.1 MB** | 88.7 ms | **11.1 ms** |
| 5000 lines, 6 terminals | 583.9 MB | **52.7 MB** | 561.9 ms | **14.3 ms** |

Per-terminal cost at full scrollback: **91.3 MB → 2.8 MB** (target was <20 MB). Gen2 pause with six full terminals: **561.9 ms → 14.3 ms** (target was <100 ms).

### End-to-end (`profile_app.py 8 1`, base and new run back to back)

| | before | after |
|---|---|---|
| CPU | 8.3s / 8.4s wall = **100% of a core** | 6.3s / 8.1s = **78%** |
| stdout chunks ingested in 8s | 116 | **318** |
| work per CPU second | 14.0 chunks | **50.5 chunks** (3.6x) |

The CPU percentage understates this badly: **the old code is saturated**, so it drops frames and falls behind the producer — it got through 116 chunks while pinning a core, where the new code got through all 318 and still had headroom. On a quiet machine the same pair reads 100% / 197 chunks vs 93% / 318 chunks after fixes 1 and 2 alone. `bench_frame.py` is the load-independent number.

### Scaling with the number of worktrees

Modelling what lazyagent actually does — one pane visible via the `ContentSwitcher`, the rest hidden. Hidden panes skip render/refresh/scroll but **still parse every byte**, so a background worktree with a busy agent is not free (min of 3):

| streaming agents | base | after | |
|---|---|---|---|
| 1 | 35.27 ms/frame | **4.68 ms** | 7.5x |
| 3 | 47.99 ms/frame | **8.75 ms** | 5.5x |
| 6 | 83.14 ms/frame | **13.17 ms** | 6.3x |
| marginal cost of each extra hidden streaming agent | 9.57 ms | **1.70 ms** | 5.6x |

Worktrees with *no* output cost nothing per frame, before and after. But the GC pause was global and scaled with every worktree holding scrollback, **whether or not its agent was still doing anything** — a worktree whose agent finished hours ago still added ~130 ms to every full collection, freezing the whole UI:

| terminals x 5000 lines | base gen2 pause | after |
|---|---|---|
| 1 | 140 ms | **14.0 ms** |
| 3 | 417 ms | **13.1 ms** |
| 6 | 774 ms | **16.8 ms** |

That dimension is now flat.

### Nothing scales with conversation length any more

`bench_longconv.py`, empty vs 5000-line scrollback: per-frame cost is **flat**. CPU now scales with output volume x number of live agents, not history size. The only remaining O(scrollback) operation is `_extract_selection` (0.8 → 3.4 ms at 5000 lines), which runs per click.

## Correctness

- Full suite green: **404 passed** (was 365; +39 new).
- New tests: run-length encoding, per-cell styles, cursor override (including the last column), selection overlay, selection+cursor interaction, style-cache memoization/invalidation/`ColorParseError` fallback, scrollback round-trip (text + styles + attributes), trailing-blank trim, gap filling, blank lines, FIFO eviction at `max_scrollback`, custom-margins no-capture, key interning, scrollback-vs-live render equality, padding, selection over scrollback, `line_text`, `ipc.read_agent_output` over real scrollback, and a 17-case `draw` differential covering every branch the fast path bails out of.
- **`test_scrollback_entries_are_gc_untracked`** asserts `gc.is_tracked(...)` is False for every stored entry, run and key after collection, with a comment explaining why. This is the invariant that silently rots if someone later swaps the tuples for a NamedTuple or dataclass — which would bring the pauses straight back.
- **`TestDrawFastPath`** feeds identical input to a patched screen and a stock-`draw` screen and compares the entire resulting state (buffer, cursor, dirty set). Cases cover wrapping, the pending-wrap state, DECAWM off, insert mode, SCS box drawing, SO/SI, wide characters, combining marks, Latin-1, `DEL`, and empty draws.
- Four throwaway differential harnesses compared old vs new output directly (not committed): 389 live-row comparisons, 978 scrollback comparisons, a full-widget dump through `render_line` at four scroll offsets with and without a selection, and a **120-run fuzz differential** of `draw` (60 random streams mixing wide chars, combining marks, wrapping, insert mode, charsets, scrolling and SGR, x `use_utf8` on/off) comparing full buffer + cursor + dirty + scrollback. **Zero differences** other than the one below.

### Behaviour note — latent bug found

The old loop's forced `stylize` at `x == ncols - 1` painted the final column with the **previous** cell's style, so a style change on the very last column was dropped. The full-widget dump shows it concretely: a red-background cell in the rightmost column renders with a **default** background today, and correctly red after this change. Any TUI that styles the right edge — a box border, a right-aligned badge, a full-width coloured bar — loses that cell's styling today.

I did not go out of my way to fix this, and I could not reproduce it without deliberately writing wrong code in two places (the live and scrollback paths reach the final column differently, so bug-compatibility would have made them inconsistent with each other). Flagging rather than hiding it: it is the only visible change in the diff.

Also left alone, as pre-existing:
- `_char_rich_style` ignores `char.dim` even though `pyte_patch` tracks it. Behaviour preserved exactly — `dim` now rides along in the style key and in scrollback, so honouring it later is a one-line change.
- While a pane is hidden, `recv()` skips the `RE_ANSI_SEQUENCE` scan that maintains `self.mouse_tracking`, and `_flush_hidden_feed` does not re-scan. An app that enables mouse tracking while its pane is hidden leaves `mouse_tracking` stale until the next visible chunk containing a DECSET sequence.
- `pyte.Stream` defaults to `use_utf8=True`, under which pyte drops SCS (`\e(0`) and SO/SI entirely, so the active charset is always Latin-1 in practice. The fast path still checks it rather than depending on a flag set elsewhere; `test_charset_selection_ignored_under_utf8` documents this.

## Out of scope / follow-up

Fix 3 makes parsing cheaper but **nothing rate-limits it** — that half of the finding is deliberately not addressed here. Notes for whoever picks it up:

- `_HIDDEN_FEED_INTERVAL` does not help: `_flush_hidden_feed` joins the buffered chunks and feeds the same bytes, so it saves the per-chunk `refresh()` / `scroll_end()` / regex pass but not the parse cost. Hidden agents are cheaper than they were, but still not free.
- Scrollback capture is driven by pyte's `index()`, not by chunk boundaries, and the compact encoder is a pure function of the row — so batching or throttling feeds cannot change scrollback content. That stays a local change.
- Ordering dependencies a throttle must preserve: `on_resize` flushes buffered output **before** `self._screen.resize(...)`, so output is applied at the geometry it was produced for; `on_show` flushes for immediate catch-up; the visible path reads `was_at_bottom` before feeding and calls `scroll_end` after.
- Cadence dependencies: `_on_stdout(chars)` runs per chunk regardless of visibility (hang detection needs it) and must not move behind a throttle; `_after_stdout_processed()` fires once per chunk when visible but once per flush when hidden, and `MonitoredTerminal`'s sentinel scanning rides on it.
- The mouse-tracking DECSET scan is per-chunk and independent of `feed`, so it can stay outside any parse throttle — but see the latent bug above; it is currently skipped entirely while hidden.
- Next cheapest wins inside the parse, if it ever matters again: `_StreamFilter.filter` is a per-character Python loop over every byte (0.48 ms/chunk) and could short-circuit chunks containing no `ESC`; `recv()`'s `RE_ANSI_SEQUENCE` scan (0.05 ms/chunk) could be guarded on `"\x1b[?" in chars`.

