### PR TITLE
fix(tui): stop freezing the UI on the periodic git-status refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `Alt+G` refreshes the git status of the selected worktree on demand, without
+  re-listing worktrees the way `r` does
+
+### Fixed
+- The periodic git-status refresh no longer freezes the UI. It ran `git status`
+  for *every* worktree, serially, on the message pump — about three seconds of
+  a completely unresponsive app twice a minute on a repo with 22 worktrees. It
+  now runs in a worker thread, polls only the selected worktree, and does so
+  once a minute instead of twice. Every worktree still refreshes on `r`, on
+  create/remove, and on MCP worktree changes
+
 ## [0.6.0] - 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   now runs in a worker thread, polls only the selected worktree, and does so
   once a minute instead of twice. Every worktree still refreshes on `r`, on
   create/remove, and on MCP worktree changes
+- Scrolling the sidebar no longer fires a `git status` for every worktree
+  passed through — the selection-triggered refresh waits for the selection to
+  settle first
 
 ## [0.6.0] - 2026-07-14
 

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -7,6 +7,7 @@ import sys
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
+from textual.timer import Timer
 from textual.widgets import Footer, Header
 from textual import work
 
@@ -24,6 +25,12 @@ from lazyagent.widgets.prompt_modal import SpawnModal, SpawnResult
 from lazyagent.widgets.orchestrator_panel import ORCHESTRATOR_KEY
 from lazyagent.widgets.worktree_list import OrchestratorListItem, WorktreeList, WorktreeListItem
 from lazyagent.worktree_manager import WorktreeManager, WorktreeManagerError, find_repo_root
+
+
+# How long the selection has to settle before we fetch its git status.
+# Scrolling the sidebar with j/k should not spawn a `git status` per worktree
+# passed through — only the one actually landed on.
+_GIT_STATUS_DEBOUNCE = 0.4
 
 
 class LazyAgent(App):
@@ -93,6 +100,7 @@ class LazyAgent(App):
         self._gh_available: bool | None = None
         self._ipc_server: IpcServer | None = None
         self._ipc_socket_path: str | None = None
+        self._git_status_debounce: Timer | None = None
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -219,6 +227,26 @@ class LazyAgent(App):
             return
         self.call_from_thread(self._apply_git_statuses, statuses)
 
+    def _cancel_git_status_debounce(self) -> None:
+        """Drop a pending selection-triggered git status fetch."""
+        if self._git_status_debounce is not None:
+            self._git_status_debounce.stop()
+            self._git_status_debounce = None
+
+    def _schedule_selected_git_status(self) -> None:
+        """Fetch the selected worktree's git status once the selection settles.
+
+        Debounced rather than immediate: scrolling the sidebar with j/k would
+        otherwise spawn a ``git status`` for every worktree passed through, and
+        those subprocesses are the expensive part. ``exclusive=True`` on the
+        worker cancels *waiting* on a superseded fetch but cannot stop a
+        subprocess already running, so the throttle has to happen here.
+        """
+        self._cancel_git_status_debounce()
+        self._git_status_debounce = self.set_timer(
+            _GIT_STATUS_DEBOUNCE, self._refresh_selected_git_status
+        )
+
     @work(thread=True, exclusive=True, group="git_status_selected")
     def _refresh_selected_git_status(self) -> None:
         """Fetch git status for the selected worktree only (runs in a thread).
@@ -314,6 +342,8 @@ class LazyAgent(App):
 
     async def on_list_view_highlighted(self, event: WorktreeList.Highlighted) -> None:
         center = self.query_one(CenterPanel)
+        # Any move invalidates a fetch queued for the worktree we just left.
+        self._cancel_git_status_debounce()
         if event.item is not None and isinstance(event.item, OrchestratorListItem):
             self._orchestrator_selected = True
             self._selected_worktree = None
@@ -323,10 +353,11 @@ class LazyAgent(App):
             self._selected_worktree = event.item.worktree
             await center.switch_to(event.item.worktree.path)
             self._push_git_status_to_selected_panel()
-            # Show the cached badge immediately, then refresh it: the periodic
-            # poll only covers whichever worktree was selected at the time, so
-            # the one we just moved to may be holding a stale status.
-            self._refresh_selected_git_status()
+            # Show the cached badge immediately, then refresh it once the
+            # selection settles: the periodic poll only covers whichever
+            # worktree was selected at the time, so the one we just moved to
+            # may be holding a stale status.
+            self._schedule_selected_git_status()
             self._refresh_selected_diff()
             self._refresh_pr_status()
         else:
@@ -562,6 +593,8 @@ class LazyAgent(App):
         """Refresh git status for the selected worktree, nothing else."""
         if self._selected_worktree is None:
             return
+        # Explicit request — fire now, and drop any debounced fetch it obsoletes.
+        self._cancel_git_status_debounce()
         self._refresh_selected_git_status()
         self.notify("Refreshing git status…", timeout=2)
 

--- a/src/lazyagent/app.py
+++ b/src/lazyagent/app.py
@@ -70,6 +70,10 @@ class LazyAgent(App):
         # bound as universal fallbacks that keep the modifier everywhere.
         Binding("alt+right_square_bracket,alt+n", "next_agent", "Next agent", priority=True),
         Binding("alt+left_square_bracket,alt+p", "prev_agent", "Prev agent", priority=True),
+        # Git status only — no worktree re-list. priority=True so it works
+        # while a terminal pane has focus, which is exactly when you want it
+        # (you just committed and want the badge to catch up).
+        Binding("alt+g", "refresh_git_status", "Git status", priority=True),
         Binding("question_mark", "help", "Help"),
     ]
 
@@ -103,7 +107,12 @@ class LazyAgent(App):
         self._load_config()
         await self._start_ipc_server()
         self.set_interval(60, self._check_hangs)
-        self.set_interval(30, self._refresh_git_statuses)
+        # Only the selected worktree is polled, and only once a minute:
+        # `git status` walks the whole working tree, so sweeping every
+        # worktree on a timer costs seconds on a repo with many of them.
+        # The other worktrees refresh on the full rescan (`r`, create,
+        # remove, MCP), and Alt+G refreshes the selected one on demand.
+        self.set_interval(60, self._refresh_selected_git_status)
         self.set_interval(30, self._refresh_selected_diff)
         self.set_interval(60, self._refresh_pr_status)
 
@@ -190,17 +199,53 @@ class LazyAgent(App):
             return center.get_orchestrator_panel()
         return center.get_panel(key)
 
+    @work(thread=True, exclusive=True, group="git_status_all")
     def _refresh_git_statuses(self) -> None:
-        """Fetch git statuses for all worktrees and push to UI."""
-        if not self._repo_root or not self.worktrees:
+        """Fetch git status for every worktree (runs in a thread).
+
+        ``git status`` walks the whole working tree — on a repo with a couple
+        of dozen worktrees this sweep takes seconds, so it must never run on
+        the message pump. Only the full-rescan paths need it; the periodic
+        poll refreshes just the selected worktree.
+        """
+        repo_root = self._repo_root
+        worktrees = list(self.worktrees)
+        if not repo_root or not worktrees:
             return
         try:
-            manager = WorktreeManager(self._repo_root)
-            self._git_statuses = manager.get_all_git_statuses(self.worktrees)
+            manager = WorktreeManager(repo_root)
+            statuses = manager.get_all_git_statuses(worktrees)
         except WorktreeManagerError:
             return
+        self.call_from_thread(self._apply_git_statuses, statuses)
 
-        self.query_one(WorktreeList).update_all_git_statuses(self._git_statuses)
+    @work(thread=True, exclusive=True, group="git_status_selected")
+    def _refresh_selected_git_status(self) -> None:
+        """Fetch git status for the selected worktree only (runs in a thread).
+
+        ``exclusive=True`` drops an in-flight fetch when the selection moves
+        or the user asks again — only the current worktree's answer matters.
+        """
+        repo_root = self._repo_root
+        wt = self._selected_worktree
+        if not repo_root or wt is None or wt.is_bare:
+            return
+        try:
+            manager = WorktreeManager(repo_root)
+            status = manager.get_git_status(wt.path)
+            status.last_commit_subject = manager.get_last_commit_subject(wt.path)
+        except WorktreeManagerError:
+            return
+        self.call_from_thread(self._apply_git_statuses, {wt.path: status})
+
+    def _apply_git_statuses(self, statuses: dict[str, GitStatus]) -> None:
+        """Merge fetched statuses into the cache and UI — runs on the main thread.
+
+        Merges rather than replaces: a selected-worktree refresh must not drop
+        the statuses the last full sweep collected for the others.
+        """
+        self._git_statuses.update(statuses)
+        self.query_one(WorktreeList).update_all_git_statuses(statuses)
         self._push_git_status_to_selected_panel()
 
     def _push_git_status_to_selected_panel(self) -> None:
@@ -278,6 +323,10 @@ class LazyAgent(App):
             self._selected_worktree = event.item.worktree
             await center.switch_to(event.item.worktree.path)
             self._push_git_status_to_selected_panel()
+            # Show the cached badge immediately, then refresh it: the periodic
+            # poll only covers whichever worktree was selected at the time, so
+            # the one we just moved to may be holding a stale status.
+            self._refresh_selected_git_status()
             self._refresh_selected_diff()
             self._refresh_pr_status()
         else:
@@ -508,6 +557,13 @@ class LazyAgent(App):
     def action_refresh(self) -> None:
         self._load_worktrees()
         self.notify("Refreshed worktrees")
+
+    def action_refresh_git_status(self) -> None:
+        """Refresh git status for the selected worktree, nothing else."""
+        if self._selected_worktree is None:
+            return
+        self._refresh_selected_git_status()
+        self.notify("Refreshing git status…", timeout=2)
 
     def action_create_worktree(self) -> None:
         def on_modal_dismiss(result: CreateWorktreeResult | None) -> None:

--- a/src/lazyagent/widgets/help_modal.py
+++ b/src/lazyagent/widgets/help_modal.py
@@ -25,7 +25,8 @@ _HELP_TEXT = """\
 [bold cyan]Worktrees[/bold cyan]
   [bold]c[/bold]               Create new worktree
   [bold]d[/bold]               Remove selected worktree
-  [bold]r[/bold]               Refresh worktree list
+  [bold]r[/bold]               Refresh worktree list (and every git status)
+  [bold]Alt+G[/bold]           Refresh git status of the selected worktree
 
 [bold cyan]Terminal scrollback[/bold cyan]
   [bold]PageUp / PageDown[/bold]  Scroll terminal history

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -16,7 +16,11 @@ from lazyagent.models import AgentState, AgentStatus, GitStatus, WorktreeInfo
 from lazyagent.widgets.center_panel import CenterPanel, WorktreePanel
 from lazyagent.widgets.create_worktree_modal import CreateWorktreeResult
 from lazyagent.widgets.remove_worktree_modal import RemoveWorktreeResult
-from lazyagent.widgets.worktree_list import WorktreeList, WorktreeListItem
+from lazyagent.widgets.worktree_list import (
+    OrchestratorListItem,
+    WorktreeList,
+    WorktreeListItem,
+)
 
 
 MAIN_WORKTREE = WorktreeInfo(
@@ -508,3 +512,110 @@ class TestGitStatusRefresh:
             b for b in LazyAgent.BINDINGS
             if isinstance(b, Binding) and b.key == "alt+g"
         ).priority is True
+
+
+class TestGitStatusDebounce:
+    """Moving through the sidebar must not fetch status for every worktree."""
+
+    @pytest.mark.asyncio
+    async def test_passing_through_worktrees_only_polls_the_final_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_app_dependencies(monkeypatch)
+        # Long window so it cannot fire mid-test: what matters is that passing
+        # through *queues* nothing, not how long the window happens to be.
+        monkeypatch.setattr("lazyagent.app._GIT_STATUS_DEBOUNCE", 30.0)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+
+            # Scroll past the first worktree and land on the second.
+            await _select_worktree(app, 0)
+            passed_through = app._git_status_debounce
+            final = await _select_worktree(app, 1)
+
+            # Neither worktree has been fetched yet...
+            assert _status_paths() == set()
+            # ...and the worktree we passed through had its pending fetch
+            # replaced rather than a second one queued alongside it.
+            assert passed_through is not None
+            assert app._git_status_debounce is not passed_through
+
+            # Firing what the timer would call fetches only where we landed.
+            app._refresh_selected_git_status()
+            await _drain_workers(app)
+
+        assert _status_paths() == {final.path}
+
+    @pytest.mark.asyncio
+    async def test_staying_on_a_worktree_polls_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The timer really does fire once the selection settles."""
+        _patch_app_dependencies(monkeypatch)
+        monkeypatch.setattr("lazyagent.app._GIT_STATUS_DEBOUNCE", 0.05)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+
+            wt = await _select_worktree(app, 1)
+            await asyncio.sleep(0.4)
+            await _drain_workers(app)
+
+        assert _status_paths() == {wt.path}
+
+    @pytest.mark.asyncio
+    async def test_leaving_for_the_orchestrator_cancels_the_pending_poll(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_app_dependencies(monkeypatch)
+        monkeypatch.setattr("lazyagent.app._GIT_STATUS_DEBOUNCE", 30.0)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+
+            await _select_worktree(app, 1)
+            assert app._git_status_debounce is not None
+
+            worktree_list = app.query_one(WorktreeList)
+            orchestrator = next(
+                child for child in worktree_list.children
+                if isinstance(child, OrchestratorListItem)
+            )
+            await app.on_list_view_highlighted(
+                WorktreeList.Highlighted(worktree_list, orchestrator)
+            )
+
+            assert app._git_status_debounce is None
+            await _drain_workers(app)
+
+        assert _status_paths() == set()
+
+    @pytest.mark.asyncio
+    async def test_on_demand_refresh_is_not_debounced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Alt+G is an explicit request — it fires immediately."""
+        _patch_app_dependencies(monkeypatch)
+        monkeypatch.setattr("lazyagent.app._GIT_STATUS_DEBOUNCE", 30.0)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            wt = await _select_worktree(app, 1)
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+            app.notify = MagicMock()
+
+            app.action_refresh_git_status()
+            await _drain_workers(app)
+
+            # Fired without waiting out the window...
+            assert _status_paths() == {wt.path}
+            # ...and dropped the pending selection-triggered fetch.
+            assert app._git_status_debounce is None

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import asyncio
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from textual.binding import Binding
 from textual.widgets import TabbedContent
+from textual.worker import WorkerState
 
 from lazyagent.app import LazyAgent
 from lazyagent.config import Config, WorktreeConfig
@@ -49,6 +53,12 @@ def _make_app_with_config(
 
 
 class DummyWorktreeManager:
+    #: (kind, path) for every git call, so tests can assert *which* worktrees
+    #: were touched. Class-level: the app builds its own manager instances.
+    calls: list[tuple[str, str]] = []
+    #: seconds each git call blocks for — used to prove the work is threaded
+    delay: float = 0.0
+
     def __init__(self, repo_path: str | Path) -> None:
         self.repo_path = Path(repo_path)
 
@@ -58,10 +68,24 @@ class DummyWorktreeManager:
     def get_all_git_statuses(
         self, worktrees: list[WorktreeInfo]
     ) -> dict[str, GitStatus]:
+        for wt in worktrees:
+            DummyWorktreeManager.calls.append(("status", wt.path))
+        if DummyWorktreeManager.delay:
+            time.sleep(DummyWorktreeManager.delay)
         return {
             wt.path: GitStatus(last_commit_subject=f"commit for {wt.name}")
             for wt in worktrees
         }
+
+    def get_git_status(self, worktree_path: str | Path) -> GitStatus:
+        DummyWorktreeManager.calls.append(("status", str(worktree_path)))
+        if DummyWorktreeManager.delay:
+            time.sleep(DummyWorktreeManager.delay)
+        return GitStatus()
+
+    def get_last_commit_subject(self, worktree_path: str | Path) -> str:
+        DummyWorktreeManager.calls.append(("subject", str(worktree_path)))
+        return f"commit for {worktree_path}"
 
     @staticmethod
     def get_diff(worktree_path: str) -> str:
@@ -85,6 +109,24 @@ def _patch_app_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
         return None
 
     monkeypatch.setattr(LazyAgent, "_refresh_pr_status", no_pr_refresh)
+
+
+async def _drain_workers(app: LazyAgent) -> None:
+    """Wait for background workers to settle.
+
+    Not ``workers.wait_for_complete()``: these workers use ``exclusive=True``,
+    and that helper re-raises ``WorkerCancelled`` for every worker an exclusive
+    call superseded — which is normal operation here, not a failure.
+    """
+    deadline = time.perf_counter() + 5.0
+    while time.perf_counter() < deadline:
+        if not [
+            w for w in app.workers
+            if w.state in (WorkerState.PENDING, WorkerState.RUNNING)
+        ]:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("workers did not finish within 5s")
 
 
 async def _select_worktree(app: LazyAgent, index: int) -> WorktreeInfo:
@@ -307,3 +349,162 @@ def test_do_create_worktree_no_extra_options() -> None:
     app._send_to_terminal.assert_called_once_with(
         "create-worktree feature/demo repo-feature/demo main /repo-feature/demo /repo"
     )
+
+
+# ---------------------------------------------------------------------------
+# Git status refresh
+# ---------------------------------------------------------------------------
+
+
+def _status_paths() -> set[str]:
+    return {path for kind, path in DummyWorktreeManager.calls if kind == "status"}
+
+
+class TestGitStatusRefresh:
+    @pytest.mark.asyncio
+    async def test_periodic_poll_only_touches_the_selected_worktree(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The timer must not sweep every worktree — that is the expensive part."""
+        _patch_app_dependencies(monkeypatch)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            wt = await _select_worktree(app, 1)
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+
+            app._refresh_selected_git_status()
+            await _drain_workers(app)
+
+        assert _status_paths() == {wt.path}
+
+    @pytest.mark.asyncio
+    async def test_full_rescan_still_covers_every_worktree(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`r` / create / remove / MCP still refresh the whole sidebar."""
+        _patch_app_dependencies(monkeypatch)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+
+            app._load_worktrees()
+            await _drain_workers(app)
+
+            assert set(app._git_statuses) == {wt.path for wt in WORKTREES}
+        assert _status_paths() == {wt.path for wt in WORKTREES}
+
+    @pytest.mark.asyncio
+    async def test_sweep_does_not_block_the_message_pump(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The regression guard: `git status` runs off the event loop.
+
+        Sweeping every worktree took ~3 s on a repo with 22 of them, and it
+        used to run inline — freezing the whole UI twice a minute. If the
+        `@work(thread=True)` decorator is ever dropped, this call blocks for
+        the full delay and the test fails.
+        """
+        _patch_app_dependencies(monkeypatch)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            DummyWorktreeManager.delay = 0.3
+            try:
+                start = time.perf_counter()
+                app._refresh_git_statuses()
+                inline = time.perf_counter() - start
+
+                start = time.perf_counter()
+                app._refresh_selected_git_status()
+                inline_selected = time.perf_counter() - start
+
+                await _drain_workers(app)
+            finally:
+                DummyWorktreeManager.delay = 0.0
+
+        assert inline < 0.1, f"full sweep blocked the pump for {inline:.2f}s"
+        assert inline_selected < 0.1, (
+            f"selected refresh blocked the pump for {inline_selected:.2f}s"
+        )
+
+    @pytest.mark.asyncio
+    async def test_selected_refresh_keeps_other_statuses(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Merging, not replacing: the sidebar must not lose the other badges."""
+        _patch_app_dependencies(monkeypatch)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            app._git_statuses = {
+                MAIN_WORKTREE.path: GitStatus(last_commit_subject="old main"),
+                FEATURE_WORKTREE.path: GitStatus(last_commit_subject="old feature"),
+            }
+
+            app._apply_git_statuses(
+                {FEATURE_WORKTREE.path: GitStatus(last_commit_subject="new feature")}
+            )
+
+            assert app._git_statuses[FEATURE_WORKTREE.path].last_commit_subject == (
+                "new feature"
+            )
+            assert app._git_statuses[MAIN_WORKTREE.path].last_commit_subject == (
+                "old main"
+            )
+
+    @pytest.mark.asyncio
+    async def test_action_refreshes_only_git_status(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Alt+G refreshes the badge without re-listing worktrees."""
+        _patch_app_dependencies(monkeypatch)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            wt = await _select_worktree(app, 1)
+            await _drain_workers(app)
+            DummyWorktreeManager.calls.clear()
+            app.notify = MagicMock()
+            reload_worktrees = MagicMock()
+            monkeypatch.setattr(LazyAgent, "_load_worktrees", reload_worktrees)
+
+            app.action_refresh_git_status()
+            await _drain_workers(app)
+
+        assert _status_paths() == {wt.path}
+        reload_worktrees.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_action_is_a_noop_without_a_selection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_app_dependencies(monkeypatch)
+        app = LazyAgent(repo_path="/repo")
+
+        async with app.run_test():
+            await _drain_workers(app)
+            app._selected_worktree = None
+            DummyWorktreeManager.calls.clear()
+
+            app.action_refresh_git_status()
+            await _drain_workers(app)
+
+        assert DummyWorktreeManager.calls == []
+
+    def test_binding_is_registered(self) -> None:
+        bindings = {
+            b.key: b.action
+            for b in LazyAgent.BINDINGS
+            if isinstance(b, Binding)
+        }
+        assert bindings["alt+g"] == "refresh_git_status"
+        assert next(
+            b for b in LazyAgent.BINDINGS
+            if isinstance(b, Binding) and b.key == "alt+g"
+        ).priority is True

--- a/tests/test_multi_agent_panel.py
+++ b/tests/test_multi_agent_panel.py
@@ -44,6 +44,12 @@ class DummyWorktreeManager:
     def get_all_git_statuses(self, worktrees):
         return {wt.path: GitStatus() for wt in worktrees}
 
+    def get_git_status(self, worktree_path):
+        return GitStatus()
+
+    def get_last_commit_subject(self, worktree_path):
+        return ""
+
     @staticmethod
     def get_diff(worktree_path):
         return ""

--- a/tests/test_orchestrator_panel.py
+++ b/tests/test_orchestrator_panel.py
@@ -44,6 +44,12 @@ class DummyWorktreeManager:
     def get_all_git_statuses(self, worktrees):
         return {wt.path: GitStatus() for wt in worktrees}
 
+    def get_git_status(self, worktree_path):
+        return GitStatus()
+
+    def get_last_commit_subject(self, worktree_path):
+        return ""
+
     @staticmethod
     def get_diff(worktree_path):
         return ""


### PR DESCRIPTION
`_refresh_git_statuses` ran **on the message pump**. It shells out twice per worktree — `git status --porcelain` walks the whole working tree — and did so for **every** worktree, serially, every 30 seconds.

Measured on a repo with 22 worktrees:

| | |
|---|---|
| one sweep | **2.8 – 3.7 s** |
| frequency | every 30 s |
| **UI frozen** | **~6 seconds of every minute** |
| git subprocesses | 88/minute |

During each sweep nothing responds: no keystrokes, no terminal output, no scrolling. It also ran on startup and on every worktree create/remove — including the ones driven over MCP, so an orchestrating agent spawning worktrees triggered a fresh 3-second freeze per worktree.

The two functions immediately below it in the same file (`_refresh_selected_diff`, `_refresh_pr_status`) already carry `@work(thread=True)`. This one did not.

## Changes

**Move it off the message pump.** Both sweeps now run in worker threads and apply their result on the main thread via `call_from_thread`, mirroring `_refresh_selected_diff`.

**Poll only the selected worktree, once a minute.** The timer drops from 30 s to 60 s and fetches one worktree instead of all of them. Every worktree still refreshes on the full-rescan paths — `r`, create, remove, MCP worktree changes — which is what the sidebar needs. The selected worktree is *also* refreshed when the selection moves, so arriving at a worktree doesn't show a badge from the last full rescan.

**Scrolling the sidebar doesn't poll.** The selection-triggered refresh is debounced by 0.4 s, so navigating with `j`/`k` fetches status only for the worktree you land on, not every one you pass through. `exclusive=True` on the worker cancels *waiting* on a superseded fetch, but a thread worker can't interrupt a subprocess that already started — so the throttle has to happen before the worker is spawned. Any move also cancels a fetch queued for the worktree just left, including moving to the orchestrator. `Alt+G` is exempt: an explicit request fires immediately and drops the pending debounce.

**Merge instead of replace.** `_git_statuses` is updated key-by-key, so a single-worktree refresh cannot drop the other sidebar badges.

**`Alt+G` refreshes the selected worktree's git status on demand** — git status only, no worktree re-list (that's still `r`). `priority=True` so it works while a terminal pane has focus, which is exactly when you want it: you just committed and want the badge to catch up.

## Result

| | before | after |
|---|---|---|
| UI blocked per sweep | 2.8–3.7 s | **0** (threaded) |
| poll frequency | 2/min | 1/min |
| worktrees polled | all 22 | **1** (selected) |
| git subprocesses/min | 88 | **2** |
| one worktree's status+subject | — | 269 ms, in a thread |

## Tests

411 → 376 on this branch (it branches from `main`, not from the terminal-performance branch, so it doesn't carry those tests).

New `TestGitStatusDebounce` covers the pass-through case, the timer actually firing once the selection settles, cancellation when leaving for the orchestrator, and `Alt+G` bypassing the window. Those assert on the timer rather than on wall-clock sleeps — a 50 ms window raced with the test's own awaits while panels mounted, which would have been flaky on a loaded CI box.

New `TestGitStatusRefresh` covers: the periodic poll touching only the selected worktree; the full rescan still covering all of them; merge-not-replace; the `Alt+G` action refreshing status without re-listing; the action being a no-op with no selection; and the binding being registered with `priority=True`.

The regression guard is `test_sweep_does_not_block_the_message_pump` — it makes the fake git calls sleep 300 ms and asserts the call returns in under 100 ms. **Verified it fails if the `@work(thread=True)` decorators are removed** (6 of the 7 new tests fail).

## Notes

- Branches from `main` and touches no terminal code, so it's independent of #44. Both add an `## [Unreleased]` CHANGELOG section, which will need a trivial merge whichever lands second.
- Threading alone removes the freeze but would keep 88 subprocesses/minute churning the disk cache; polling one worktree addresses that half. If you'd rather keep all worktrees fresh on the timer, the alternative is running the 22 subprocesses concurrently (~170 ms wall instead of ~3000 ms) — say the word and I'll switch it.
- Found while profiling terminal lag for #44; this turned out to dominate everything in that PR by three orders of magnitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
